### PR TITLE
Adapt the install command to the helm 3.x version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before deploying Chaos Mesh, make sure the following items have been installed. 
 
 - Kubernetes >= v1.12
 - [RBAC](https://kubernetes.io/docs/admin/authorization/rbac) enabled (optional)
-- [Helm](https://helm.sh/) version >= v2.8.2 and < v3.0.0
+- [Helm](https://helm.sh/) version >= v2.8.2
 
 ## Deploy Chaos Mesh
 
@@ -64,14 +64,23 @@ kubectl get crd podchaos.pingcap.com
 * Install Chaos Mesh with Chaos Operator only
 
 ```bash
+# create namespace chaos-testing
+kubectl create ns chaos-testing
+# helm 2.X
 helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing
+# helm 3.X
+helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing
+# check Chaos Mesh pods installed
 kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh
 ```
 
 * Install Chaos Mesh with Chaos Operator and Chaos Dashboard
 
 ```bash
+# helm 2.X
 helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set dashboard.create=true
+# helm 3.X
+helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set dashboard.create=true
 ```
 
 ## Get started on your local machine


### PR DESCRIPTION
Fix the install command and some comments.
Until helm2 reached EOL,we would use the both helm version via 2.x and 3.x.

### What problem does this PR solve? <!--add and issue link with summary if exists-->
fixes #165 

### What is changed and how does it work?
Add the install command with helm 3.x.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
