### PR TITLE
Add maintainers to Chaos Mesh

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,7 @@ The maintainers of Chaos Mesh, along with their email and focus area,
 
 Name | Email | Focus
 ----|---|---
-[Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead[Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead[CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard
+[Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead[Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead
+[CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard
 
 > *Please do not contact the maintainers listed above for any reason not directly related to the Chaos Mesh project. For issues, questions, or support, you are asked to **use the issue tracker whenever possible.***

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,10 +1,12 @@
 # The Chaos Mesh Maintainers
+
 This file lists who are the maintainers of the Chaos Mesh project.
 
 In short,maintainers are people who are in charge of the maintenance of the Chaos Mesh project. This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
 The maintainers of Chaos Mesh, along with their email and focus area, are listed below:
 
 ## Senior Maintainers
+
 Name | Email | Focus
 ----|---|---
 [Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead[Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead[CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-# The Chaos Mesh Maintainers
+# The Chaos Mesh Maintainers
 
 This file lists who are the maintainers of the Chaos Mesh project.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,8 +2,7 @@
 
 This file lists who are the maintainers of the Chaos Mesh project.
 
-In short,maintainers are people who are in charge of the maintenance of the Chaos Mesh project.
-This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
+In short, maintainers are people who are in charge of the maintenance of the Chaos Mesh project. This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
 
 The maintainers of Chaos Mesh, along with their email and focus area, are listed below:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,12 +5,12 @@ This file lists who are the maintainers of the Chaos Mesh project.
 In short,maintainers are people who are in charge of the maintenance of the Chaos Mesh project. This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
 The maintainers of Chaos Mesh, along with their email and focus area, are listed below:
 
-## Senior Maintainers
+## Senior Maintainers
 
 Name | Email | Focus
 ----|---|---
 [Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead
-[CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard
 [Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead
+[CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard
 
 > *Please do not contact the maintainers listed above for any reason not directly related to the Chaos Mesh project. For issues, questions, or support, you are asked to **use the issue tracker whenever possible.***

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,8 @@ The maintainers of Chaos Mesh, along with their email and focus area,
 
 Name | Email | Focus
 ----|---|---
-[Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead[Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead
+[Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead
 [CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard
+[Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead
 
 > *Please do not contact the maintainers listed above for any reason not directly related to the Chaos Mesh project. For issues, questions, or support, you are asked to **use the issue tracker whenever possible.***

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,12 @@
+# The Chaos Mesh Maintainers
+This file lists who are the maintainers of the Chaos Mesh project.
+
+In short,maintainers are people who are in charge of the maintenance of the Chaos Mesh project. This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
+The maintainers of Chaos Mesh, along with their email and focus area, are listed below:
+
+## Senior Maintainers
+Name | Email | Focus
+----|---|---
+[Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead[Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead[CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard
+
+> *Please do not contact the maintainers listed above for any reason not directly related to the Chaos Mesh project. For issues, questions, or support, you are asked to **use the issue tracker whenever possible.***

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,7 +6,6 @@ In short, maintainers are people who are in charge of the maintenance of the Cha
 
 The maintainers of Chaos Mesh, along with their email and focus area, are listed below:
 
-## Senior Maintainers
 
 Name | Email | Focus
 ----|---|---

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,9 @@
 
 This file lists who are the maintainers of the Chaos Mesh project.
 
-In short,maintainers are people who are in charge of the maintenance of the Chaos Mesh project. This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
+In short,maintainers are people who are in charge of the maintenance of the Chaos Mesh project.
+This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
+
 The maintainers of Chaos Mesh, along with their email and focus area, are listed below:
 
 ## Senior Maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,4 @@
-# The Chaos Mesh Maintainers
+# Maintainers
 
 This file lists who are the maintainers of the Chaos Mesh project.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,5 +13,3 @@ Name | Email | Focus
 [Siddon Tang](https://github.com/siddontang) | [tl@pingcap.com](mailto:tl@pingcap.com) | Project Lead
 [Qiang Zhou](https://github.com/zhouqiang-cl) | [zhouqiang@pingcap.com](mailto:zhouqiang@pingcap.com) | Project Lead
 [CWen](https://github.com/cwen0) | [cwen@pingcap.com](mailto:cwen@pingcap.com) | Operator, Dashboard
-
-> *Please do not contact the maintainers listed above for any reason not directly related to the Chaos Mesh project. For issues, questions, or support, you are asked to **use the issue tracker whenever possible.***

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,6 @@
 # Maintainers
 
-This file lists who are the maintainers of the Chaos Mesh project.
+This file lists the initial committers, and hence the maintainers of the Chaos Mesh project.
 
 In short, maintainers are people who are in charge of the maintenance of the Chaos Mesh project. This includes everything from day-to-day tasks such as issue triage to completing epics. Maintainers should be the first point of contact for security issues or other critical issues that require privacy not offered by the issue tracker.
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->
Add maintainers to Chaos Mesh. The maintainers may be change overtime

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - No code changes

Side effects

 - None

Related changes

 - None
