### PR TITLE
Fix networkchaos panic caused by duration being nil

### DIFF
--- a/controllers/networkchaos/netem/types.go
+++ b/controllers/networkchaos/netem/types.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	networkDelayActionMsg = "delay network for %s"
+	networkNetemActionMsg = "network netem action duration %s"
 )
 
 // NetemSpec defines the interface to convert to a Netem protobuf
@@ -109,7 +109,10 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos reconcil
 			HostIP:    pod.Status.HostIP,
 			PodIP:     pod.Status.PodIP,
 			Action:    string(networkchaos.Spec.Action),
-			Message:   fmt.Sprintf(networkDelayActionMsg, *networkchaos.Spec.Duration),
+		}
+
+		if networkchaos.Spec.Duration != nil {
+			ps.Message = fmt.Sprintf(networkNetemActionMsg, *networkchaos.Spec.Duration)
 		}
 
 		networkchaos.Status.Experiment.Pods = append(networkchaos.Status.Experiment.Pods, ps)

--- a/controllers/networkchaos/partition/types.go
+++ b/controllers/networkchaos/partition/types.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	networkPartitionActionMsg = "part network for %s"
+	networkPartitionActionMsg = "partition network duration %s"
 
 	sourceIpSetPostFix = "src"
 	targetIpSetPostFix = "tgt"
@@ -161,7 +161,10 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos reconcil
 			HostIP:    pod.Status.HostIP,
 			PodIP:     pod.Status.PodIP,
 			Action:    string(networkchaos.Spec.Action),
-			Message:   fmt.Sprintf(networkPartitionActionMsg, *networkchaos.Spec.Duration),
+		}
+
+		if networkchaos.Spec.Duration != nil {
+			ps.Message = fmt.Sprintf(networkPartitionActionMsg, *networkchaos.Spec.Duration)
 		}
 
 		networkchaos.Status.Experiment.Pods = append(networkchaos.Status.Experiment.Pods, ps)


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->
fix controller-manager panic 

panic log:  
```
2020-02-08T10:17:58.144Z        INFO    controllers.NetworkChaos        Try to apply netem on pod       {"reconciler": "networkchaos", "action": "netem", "namespace": "nginx-ns
", "name": "nginx-deployment-5c689d88bb-425zp"}
2020-02-08T10:17:58.144Z        INFO    util    Creating client to chaos-daemon {"node": "kind-worker5"}
E0208 10:17:58.274823       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer derefe$
ence)
goroutine 258 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x14cc560, 0x239f1d0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191121015412-41065c7a8c2a/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191121015412-41065c7a8c2a/pkg/util/runtime/runtime.go:48 +0x82
panic(0x14cc560, 0x239f1d0)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/pingcap/chaos-mesh/controllers/networkchaos/netem.(*Reconciler).Apply(0xc000245260, 0x18bc9e0, 0xc0000c0208, 0xc0000446c0, 0xd, 0xc0004e45e0, 0x15, 0x18bcbe0, 0xc00$
15d800, 0x0, ...)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/src/github.com/pingcap/chaos-mesh/controllers/networkchaos/netem/types.go:112 +0x1ee
github.com/pingcap/chaos-mesh/controllers/common.(*Reconciler).Reconcile(0xc000219aa0, 0xc0000446c0, 0xd, 0xc0004e45e0, 0x15, 0xc000245240, 0x8, 0x13bd207, 0xc)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/src/github.com/pingcap/chaos-mesh/controllers/common/types.go:74 +0x5c1
github.com/pingcap/chaos-mesh/controllers/networkchaos.(*Reconciler).commonNetworkChaos(0xc000521c40, 0xc00015d200, 0xc0000446c0, 0xd, 0xc0004e45e0, 0x15, 0x15, 0x188bc20, 0xc$
0015d200, 0x0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/src/github.com/pingcap/chaos-mesh/controllers/networkchaos/types.go:73 +0x2fb
github.com/pingcap/chaos-mesh/controllers/networkchaos.(*Reconciler).Reconcile(0xc000521c40, 0xc0000446c0, 0xd, 0xc0004e45e0, 0x15, 0xc0002451e0, 0x2807f9400245100, 0x5e3e8ad6$
 0xc0000a9c60)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/src/github.com/pingcap/chaos-mesh/controllers/networkchaos/types.go:53 +0x3a2
github.com/pingcap/chaos-mesh/controllers.(*NetworkChaosReconciler).Reconcile(0xc00044ab60, 0xc0000446c0, 0xd, 0xc0004e45e0, 0x15, 0xc0000a9cd8, 0xc0004b45a0, 0xc0004b4488, 0x$
8922c0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/src/github.com/pingcap/chaos-mesh/controllers/networkchaos_controller.go:43 +0x10e
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0004cc6c0, 0x151fc60, 0xc000245100, 0xc000228d00)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:256 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0004cc6c0, 0x0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:232 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc0004cc6c0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0003fa460)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191121015412-41065c7a8c2a/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0003fa460, 0x3b9aca00, 0x0, 0x1, 0xc0004f0ba0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191121015412-41065c7a8c2a/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc0003fa460, 0x3b9aca00, 0xc0004f0ba0)
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20191121015412-41065c7a8c2a/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /home/jenkins/agent/workspace/build_chaos_mesh_master/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.4.0/pkg/internal/controller/controller.go:193 +0x328
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
```
### What is changed and how does it work? 

check `duration` field before using it 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
2020-02-08T10:36:18.183Z        INFO    controllers.NetworkChaos        reconciling a common chaos      {"reconciler": "networkchaos", "action": "netem", "name": "network-delay
-example", "namespace": "chaos-testing"}
2020-02-08T10:36:18.183Z        INFO    controllers.NetworkChaos        Performing Action       {"reconciler": "networkchaos", "action": "netem"}
2020-02-08T10:36:18.184Z        INFO    controller-runtime.controller   Starting workers{"controller": "podchaos", "worker count": 1}
2020-02-08T10:36:18.284Z        INFO    controllers.NetworkChaos        Try to apply netem on pod       {"reconciler": "networkchaos", "action": "netem", "namespace": "nginx-ns
", "name": "nginx-deployment-5c689d88bb-425zp"}
2020-02-08T10:36:18.284Z        INFO    util    Creating client to chaos-daemon {"node": "kind-worker5"}
2020-02-08T10:36:18.421Z        DEBUG   controller-runtime.controller   Successfully Reconciled {"controller": "networkchaos", "request": "chaos-testing/network-delay-example"}
2020-02-08T10:36:18.422Z        INFO    controllers.NetworkChaos        reconciling networkchaos        {"reconciler": "networkchaos"}
2020-02-08T10:36:18.422Z        INFO    controllers.NetworkChaos        reconciling a common chaos      {"reconciler": "networkchaos", "action": "netem", "name": "network-delay
-example", "namespace": "chaos-testing"}
2020-02-08T10:36:18.422Z        INFO    controllers.NetworkChaos        Performing Action       {"reconciler": "networkchaos", "action": "netem"}
2020-02-08T10:36:18.422Z        INFO    controllers.NetworkChaos        Try to apply netem on pod       {"reconciler": "networkchaos", "action": "netem", "namespace": "nginx-ns
", "name": "nginx-deployment-5c689d88bb-425zp"}
2020-02-08T10:36:18.422Z        INFO    util    Creating client to chaos-daemon {"node": "kind-worker5"}
2020-02-08T10:36:18.452Z        DEBUG   controller-runtime.controller   Successfully Reconciled {"controller": "networkchaos", "request": "chaos-testing/network-delay-example"}
^C
```

Code changes

 - Has Go code change

