### PR TITLE
Fix nil error during duration chaos reconciling

### DIFF
--- a/controllers/iochaos/fs/util.go
+++ b/controllers/iochaos/fs/util.go
@@ -23,12 +23,16 @@ import (
 )
 
 const (
-	ioChaosDelayActionMsg = "inject file system io delay for %s"
-	ioChaosErrnoActionMsg = "inject file system errno delay for %s"
-	ioChaosMixedChaosMsg  = "inject file system mixed chaos for %s"
+	ioChaosDelayActionMsg  = "inject file system io delay for %s"
+	ioChaosErrnoActionMsg  = "inject file system errno delay for %s"
+	ioChaosMixedChaosMsg   = "inject file system mixed chaos for %s"
+	ioChaosCommonActionMsg = "inject file system %s until recover by deleted"
 )
 
 func genMessage(iochaos *v1alpha1.IoChaos) string {
+	if iochaos.Spec.Duration == nil {
+		return fmt.Sprintf(ioChaosCommonActionMsg, iochaos.Spec.Action)
+	}
 	switch iochaos.Spec.Action {
 	case v1alpha1.IODelayAction:
 		return fmt.Sprintf(ioChaosDelayActionMsg, *iochaos.Spec.Duration)

--- a/controllers/networkchaos/netem/types.go
+++ b/controllers/networkchaos/netem/types.go
@@ -38,7 +38,8 @@ import (
 )
 
 const (
-	networkDelayActionMsg = "delay network for %s"
+	networkDelaySchedulerActionMsg = "delay network for %s"
+	networkDelayCommonActionMsg    = "delay network perform until recover by deleted"
 )
 
 // NetemSpec defines the interface to convert to a Netem protobuf
@@ -109,7 +110,10 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos reconcil
 			HostIP:    pod.Status.HostIP,
 			PodIP:     pod.Status.PodIP,
 			Action:    string(networkchaos.Spec.Action),
-			Message:   fmt.Sprintf(networkDelayActionMsg, *networkchaos.Spec.Duration),
+			Message:   networkDelayCommonActionMsg,
+		}
+		if networkchaos.Spec.Duration != nil {
+			ps.Message = fmt.Sprintf(networkDelaySchedulerActionMsg, *networkchaos.Spec.Duration)
 		}
 
 		networkchaos.Status.Experiment.Pods = append(networkchaos.Status.Experiment.Pods, ps)

--- a/controllers/networkchaos/partition/types.go
+++ b/controllers/networkchaos/partition/types.go
@@ -37,10 +37,10 @@ import (
 )
 
 const (
-	networkPartitionActionMsg = "part network for %s"
-
-	sourceIpSetPostFix = "src"
-	targetIpSetPostFix = "tgt"
+	networkPartitionScheduleActionMsg = "part network for %s"
+	networkPartitionCommonActionMsg   = "part network perform until recover by deleted"
+	sourceIpSetPostFix                = "src"
+	targetIpSetPostFix                = "tgt"
 )
 
 func newReconciler(c client.Client, log logr.Logger, req ctrl.Request) twophase.Reconciler {
@@ -161,7 +161,10 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, chaos reconcil
 			HostIP:    pod.Status.HostIP,
 			PodIP:     pod.Status.PodIP,
 			Action:    string(networkchaos.Spec.Action),
-			Message:   fmt.Sprintf(networkPartitionActionMsg, *networkchaos.Spec.Duration),
+			Message:   networkPartitionCommonActionMsg,
+		}
+		if networkchaos.Spec.Duration != nil {
+			ps.Message = fmt.Sprintf(networkPartitionScheduleActionMsg, *networkchaos.Spec.Duration)
 		}
 
 		networkchaos.Status.Experiment.Pods = append(networkchaos.Status.Experiment.Pods, ps)

--- a/controllers/podchaos/podfailure/types.go
+++ b/controllers/podchaos/podfailure/types.go
@@ -43,7 +43,8 @@ const (
 	// fakeImage is a not-existing image.
 	fakeImage = "pingcap.com/fake-chaos-mesh:latest"
 
-	podFailureActionMsg = "pause pod duration %s"
+	podFailureSchedulerActionMsg = "pause pod duration %s"
+	podFailureCommonActionMsg    = "pause pod until recover by deleted"
 )
 
 // NewTwoPhaseReconciler would create Reconciler for twophase package
@@ -108,9 +109,10 @@ func (r *Reconciler) Apply(ctx context.Context, req ctrl.Request, obj reconciler
 			HostIP:    pod.Status.HostIP,
 			PodIP:     pod.Status.PodIP,
 			Action:    string(podchaos.Spec.Action),
+			Message:   podFailureCommonActionMsg,
 		}
 		if podchaos.Spec.Duration != nil {
-			ps.Message = fmt.Sprintf(podFailureActionMsg, *podchaos.Spec.Duration)
+			ps.Message = fmt.Sprintf(podFailureSchedulerActionMsg, *podchaos.Spec.Duration)
 		}
 		podchaos.Status.Experiment.Pods = append(podchaos.Status.Experiment.Pods, ps)
 	}


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix nil point error during duration chaos reconciling. 

The `Reconcile` in `networkchaos` /  `iochaos` would sync pod status and send message which would cause nil point error duriong `common` chaos reconciling because the `Duration` property is nil in that time. In this request, the message sent to the pod status would be const when the kind of chaos action is duration.


### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
