### PR TITLE
Fix errors in `hack/kind-cluster-build.sh` with helm3

### DIFF
--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -215,7 +215,8 @@ kubectl apply -f ${ROOT}/manifests/local-volume-provisioner.yaml
 kubectl apply -f ${ROOT}/manifests/tiller-rbac.yaml
 
 kubectl create ns chaos-testing
-helm init --service-account=tiller --wait
+
+if [[ $(helm version --client --short) == "Client: v2"* ]]; then helm init --service-account=tiller --wait; fi
 
 echo "############# success create cluster:[${clusterName}] #############"
 


### PR DESCRIPTION
### What problem does this PR solve?

Errors when helm3 is installed

```
Error: unknown flag: --service-account
```

### What is changed and how does it work?

Check helm version and by pass init for v3

### Check List

Tests

 - Manual test by running the script

Code changes

 - Has hack code change

### Does this PR introduce a user-facing change?:

```release-note
NONE
```