### PR TITLE
Support prometheus metrics in chaos-daemon

### DIFF
--- a/cmd/chaos-daemon/main.go
+++ b/cmd/chaos-daemon/main.go
@@ -35,8 +35,8 @@ var (
 
 func init() {
 	flag.BoolVar(&printVersion, "version", false, "print version information and exit")
-	flag.IntVar(&conf.GRPCPort, "grpc-port", 8080, "the port which grpc server listens on")
-	flag.IntVar(&conf.HTTPPort, "http-port", 8081, "the port which http server listens on")
+	flag.IntVar(&conf.GRPCPort, "grpc-port", 31767, "the port which grpc server listens on")
+	flag.IntVar(&conf.HTTPPort, "http-port", 31766, "the port which http server listens on")
 	flag.StringVar(&conf.Runtime, "runtime", "docker", "current container runtime")
 
 	flag.Parse()

--- a/go.mod
+++ b/go.mod
@@ -21,17 +21,21 @@ require (
 	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
 	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
+	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/hanwen/go-fuse v0.0.0-20190111173210-425e8d5301f6
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/oklog/run v1.1.0
 	github.com/onsi/ginkgo v1.11.0
 	github.com/onsi/gomega v1.7.0
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v0.1.1 // indirect
 	github.com/opencontainers/runtime-spec v1.0.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/prometheus/client_golang v1.0.0
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2 // indirect
 	github.com/unrolled/render v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -223,7 +223,9 @@ github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7 h1:6TSoaYExHpe
 github.com/gregjones/httpcache v0.0.0-20170728041850-787624de3eb7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v0.0.0-20190222133341-cfaf5686ec79/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4 h1:z53tR0945TRRQO/fLEVPI6SMv7ZflF0TEaTAoU7tOzg=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
+github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.3.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -299,6 +301,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.4.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/helm/chaos-mesh/templates/chaos-daemon-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-deployment.yaml
@@ -33,6 +33,10 @@ spec:
             - /usr/local/bin/chaos-daemon
             - --runtime
             - {{ .Values.chaosDaemon.runtime }}
+            - --http-port
+            - !!str {{ .Values.chaosDaemon.httpPort }}
+            - --grpc-port
+            - !!str {{ .Values.chaosDaemon.grpcPort }}
           env:
             - name: PORT
               value: !!str {{ .Values.chaosDaemon.port }}
@@ -48,8 +52,11 @@ spec:
               mountPath: /run/containerd/containerd.sock
               {{- end }}
           ports:
-            - containerPort: {{ .Values.chaosDaemon.port }}
-              hostPort: {{ .Values.chaosDaemon.port }}
+            - name: grpc
+              containerPort: {{ .Values.chaosDaemon.grpcPort }}
+              hostPort: {{ .Values.chaosDaemon.grpcPort }}
+            - name: http
+              containerPort: {{ .Values.chaosDaemon.httpPort }}
       volumes:
         - name: proc
           hostPath:

--- a/helm/chaos-mesh/templates/chaos-daemon-deployment.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-deployment.yaml
@@ -41,9 +41,6 @@ spec:
             - !!str {{ .Values.chaosDaemon.httpPort }}
             - --grpc-port
             - !!str {{ .Values.chaosDaemon.grpcPort }}
-          env:
-            - name: PORT
-              value: !!str {{ .Values.chaosDaemon.port }}
           securityContext:
             privileged: true
           volumeMounts:

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -43,7 +43,7 @@ spec:
           - name: TZ
             value: {{ .Values.timezone | default "UTC" }}
           - name: CHAOS_DAEMON_PORT
-            value: !!str {{ .Values.chaosDaemon.port }}
+            value: !!str {{ .Values.chaosDaemon.grpcPort }}
         volumeMounts:
           - name: webhook-certs
             mountPath: /etc/webhook/certs

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -46,7 +46,8 @@ controllerManager:
 chaosDaemon:
   image: pingcap/chaos-daemon:latest
   imagePullPolicy: Always
-  port: 31767
+  grpcPort: 31767
+  httpPort: 31766
 
   # runtime specifies which container runtime to use. Currently
   # we only supports docker and containerd.

--- a/pkg/chaosdaemon/http.go
+++ b/pkg/chaosdaemon/http.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package chaosdaemon
 
 import (

--- a/pkg/chaosdaemon/http.go
+++ b/pkg/chaosdaemon/http.go
@@ -1,0 +1,24 @@
+package chaosdaemon
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+func newHTTPServer(addr string, reg prometheus.Gatherer) *http.Server {
+	mux := http.NewServeMux()
+	registerMetrics(mux, reg)
+
+	return &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+}
+
+func registerMetrics(mux *http.ServeMux, g prometheus.Gatherer) {
+	if g != nil {
+		mux.Handle("/metrics", promhttp.HandlerFor(g, promhttp.HandlerOpts{}))
+	}
+}

--- a/pkg/chaosdaemon/ipset_server.go
+++ b/pkg/chaosdaemon/ipset_server.go
@@ -29,7 +29,7 @@ const (
 	ipsetNewNameExistErr = "a set with the new name already exists"
 )
 
-func (s *Server) FlushIpSet(ctx context.Context, req *pb.IpSetRequest) (*empty.Empty, error) {
+func (s *daemonServer) FlushIpSet(ctx context.Context, req *pb.IpSetRequest) (*empty.Empty, error) {
 	log.Info("flush ipset", "request", req)
 
 	pid, err := s.crClient.GetPidFromContainerID(ctx, req.ContainerId)
@@ -68,7 +68,7 @@ func (s *Server) FlushIpSet(ctx context.Context, req *pb.IpSetRequest) (*empty.E
 	return &empty.Empty{}, nil
 }
 
-func (s *Server) createIPSet(ctx context.Context, nsPath string, name string) error {
+func (s *daemonServer) createIPSet(ctx context.Context, nsPath string, name string) error {
 	// ipset name cannot be longer than 31 bytes
 	if len(name) > 31 {
 		name = name[:31]
@@ -100,7 +100,7 @@ func (s *Server) createIPSet(ctx context.Context, nsPath string, name string) er
 	return nil
 }
 
-func (s *Server) addIpsToIPSet(ctx context.Context, nsPath string, name string, ips []string) error {
+func (s *daemonServer) addIpsToIPSet(ctx context.Context, nsPath string, name string, ips []string) error {
 	for _, ip := range ips {
 		cmd := withNetNS(ctx, nsPath, "ipset", "add", name, ip)
 
@@ -119,7 +119,7 @@ func (s *Server) addIpsToIPSet(ctx context.Context, nsPath string, name string, 
 	return nil
 }
 
-func (s *Server) renameIPSet(ctx context.Context, nsPath string, oldName string, newName string) error {
+func (s *daemonServer) renameIPSet(ctx context.Context, nsPath string, oldName string, newName string) error {
 	cmd := withNetNS(ctx, nsPath, "ipset", "rename", oldName, newName)
 
 	log.Info("rename ipset", "command", cmd.String())

--- a/pkg/chaosdaemon/iptables_server.go
+++ b/pkg/chaosdaemon/iptables_server.go
@@ -31,7 +31,7 @@ const (
 	iptablesIpSetNotExistErr = "doesn't exist.\n\nTry `iptables -h' or 'iptables --help' for more information.\n"
 )
 
-func (s *Server) FlushIptables(ctx context.Context, req *pb.IpTablesRequest) (*empty.Empty, error) {
+func (s *daemonServer) FlushIptables(ctx context.Context, req *pb.IpTablesRequest) (*empty.Empty, error) {
 	log.Info("flush iptables rules", "request", req)
 
 	pid, err := s.crClient.GetPidFromContainerID(ctx, req.ContainerId)
@@ -73,7 +73,7 @@ func (s *Server) FlushIptables(ctx context.Context, req *pb.IpTablesRequest) (*e
 	return &empty.Empty{}, nil
 }
 
-func (s *Server) addIptablesRules(ctx context.Context, cmd *exec.Cmd) error {
+func (s *daemonServer) addIptablesRules(ctx context.Context, cmd *exec.Cmd) error {
 	log.Info("add iptables rules", "command", cmd.String())
 
 	out, err := cmd.CombinedOutput()
@@ -85,7 +85,7 @@ func (s *Server) addIptablesRules(ctx context.Context, cmd *exec.Cmd) error {
 	return nil
 }
 
-func (s *Server) deleteIptablesRules(ctx context.Context, cmd *exec.Cmd) error {
+func (s *daemonServer) deleteIptablesRules(ctx context.Context, cmd *exec.Cmd) error {
 	log.Info("delete iptables rules", "command", cmd.String())
 
 	out, err := cmd.CombinedOutput()

--- a/pkg/chaosdaemon/netem_server.go
+++ b/pkg/chaosdaemon/netem_server.go
@@ -24,7 +24,7 @@ import (
 	pb "github.com/pingcap/chaos-mesh/pkg/chaosdaemon/pb"
 )
 
-func (s *Server) SetNetem(ctx context.Context, in *pb.NetemRequest) (*empty.Empty, error) {
+func (s *daemonServer) SetNetem(ctx context.Context, in *pb.NetemRequest) (*empty.Empty, error) {
 	log.Info("set netem", "Request", in)
 
 	pid, err := s.crClient.GetPidFromContainerID(ctx, in.ContainerId)
@@ -40,7 +40,7 @@ func (s *Server) SetNetem(ctx context.Context, in *pb.NetemRequest) (*empty.Empt
 	return &empty.Empty{}, nil
 }
 
-func (s *Server) DeleteNetem(ctx context.Context, in *pb.NetemRequest) (*empty.Empty, error) {
+func (s *daemonServer) DeleteNetem(ctx context.Context, in *pb.NetemRequest) (*empty.Empty, error) {
 	log.Info("delete netem", "Request", in)
 
 	pid, err := s.crClient.GetPidFromContainerID(ctx, in.ContainerId)

--- a/pkg/chaosdaemon/server.go
+++ b/pkg/chaosdaemon/server.go
@@ -24,11 +24,10 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	pb "github.com/pingcap/chaos-mesh/pkg/chaosdaemon/pb"
 	"github.com/pingcap/chaos-mesh/pkg/utils"
-
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var log = ctrl.Log.WithName("chaos-daemon-server")
@@ -67,14 +66,14 @@ func newGRPCServer(containerRuntime string, reg *prometheus.Registry) (*grpc.Ser
 
 	grpcMetrics := grpc_prometheus.NewServerMetrics()
 	grpcMetrics.EnableHandlingTimeHistogram(
-		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 9, 20}),
+		grpc_prometheus.WithHistogramBuckets([]float64{0.001, 0.01, 0.1, 0.3, 0.6, 1, 3, 6, 10}),
 	)
 	reg.MustRegister(grpcMetrics)
 
 	grpcOpts := []grpc.ServerOption{
 		grpc_middleware.WithUnaryServerChain(
-			grpcMetrics.UnaryServerInterceptor(),
 			utils.TimeoutServerInterceptor,
+			grpcMetrics.UnaryServerInterceptor(),
 		),
 	}
 


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This PR adds some basic prometheus metrics to chaos-daemon:

1. process metrics
2. go metrics
3. grpc metrics

Since we need to expose `/metrics` http endpoint, so add a `http-port` to chaos-daemon.

Also, refactor a little bit of code in chaos-daemon to make it more readable. This seems make this PR much larger, but I cannot come up with a way to split it. So feel free to review and comment on this PR!

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The previous `port` parameter in chaos-daemon is renamed to `grpc-port`. 
Add a new `http-port` in chaos-daemon to specify the port for Prometheus metrics.
```
