### PR TITLE
Add etcd iochaos example

### DIFF
--- a/examples/etcd/etcd-configmap.yaml
+++ b/examples/etcd/etcd-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: webhook
 data:
   chaosfs-etcd.yaml: |
-    name: chaosfs-pd
+    name: chaosfs-etcd
     initContainers:
     - name: inject-scripts
       image: pingcap/chaos-scripts:latest

--- a/examples/etcd/etcd-iochaos.yaml
+++ b/examples/etcd/etcd-iochaos.yaml
@@ -1,0 +1,19 @@
+apiVersion: pingcap.com/v1alpha1
+kind: IoChaos
+metadata:
+  name: io-delay-example
+spec:
+  action: delay
+  mode: one
+  duration: "400s"
+  configName: "chaosfs-etcd"
+  path: ""
+  selector:
+    namespaces:
+      - chaos-testing
+    labelSelectors:
+      app: etcd
+  layer: "fs"
+  delay: "100ms"
+  scheduler:
+    cron: "@every 10m"

--- a/examples/etcd/etcd.yaml
+++ b/examples/etcd/etcd.yaml
@@ -1,0 +1,39 @@
+---
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: etcd
+  namespace: chaos-testing
+  labels:
+    app: etcd
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: etcd
+  template:
+    metadata:
+      labels:
+        app: etcd
+    spec:
+      containers:
+        - name: etcd
+          imagePullPolicy: IfNotPresent
+          image: k8s.gcr.io/etcd:3.4.3-0
+          args:
+            - /usr/local/bin/etcd
+            - -name=etcd
+            - -advertise-client-urls=http://0.0.0.0:2379
+            - -initial-advertise-peer-urls=http://0.0.0.0:2380
+            - -listen-client-urls=http://0.0.0.0:2379
+            - -listen-peer-urls=http://0.0.0.0:2380
+            - -initial-cluster=etcd=http://0.0.0.0:2380
+            - --data-dir=/var/run/etcd/default.etcd
+            - -initial-cluster-state=new
+            - -initial-cluster-token=etcd-cluster
+          volumeMounts:
+          - mountPath: /var/run/etcd
+            name: datadir
+      volumes:
+        - emptyDir: {}
+          name: datadir

--- a/scripts/wait-fuse.sh
+++ b/scripts/wait-fuse.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eo pipefail
+#set -eo pipefail
 #set -x # For debugging
 
 FUSE_PID_FILE="/tmp/fuse/pid"
@@ -52,7 +52,7 @@ wait_for() {
         else
             echo "fuse server not running, ${file} not found, retry..."
             sleep ${delay}
-            let count=$count+1
+            count=$count+1
         fi
     done
 }


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fixes #216.

Etcd can achieve the same purpose for iochaos testing and it is easier with the help of etcdctl.

Verification:

```
# with iochaos delay
# etcdctl check perf
 60 / 60 Boooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00% 1m0s
FAIL: Throughput too low: 79 writes/s
Slowest request took too long: 6.761501s
Stddev too high: 1.384703s
FAIL

# no iochaos
# etcdctl check perf
 60 / 60 Boooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo! 100.00% 1m0s
PASS: Throughput is 150 writes/s
PASS: Slowest request took 0.029531s
PASS: Stddev is 0.001335s
PASS
```

cc @Yisaer 

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
