### PR TITLE
Expose chaos controller metrics in helm chart

### DIFF
--- a/cmd/controller-manager/main.go
+++ b/cmd/controller-manager/main.go
@@ -64,7 +64,7 @@ func init() {
 }
 
 func parseFlags() {
-	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	flag.StringVar(&metricsAddr, "metrics-addr", ":10080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&certsDir, "certs", "/etc/webhook/certs",

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           - name: webhook
             containerPort: 9443 # Customize containerPort
           - name: http
-            containerPort: 8080
+            containerPort: 10080
       volumes:
         - name: webhook-certs
           secret:

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -53,8 +53,10 @@ spec:
             mountPath: /etc/webhook/certs
             readOnly: true
         ports:
-          - name: webhook-api
+          - name: webhook
             containerPort: 9443 # Customize containerPort
+          - name: http
+            containerPort: 8080
       volumes:
         - name: webhook-certs
           secret:

--- a/helm/chaos-mesh/templates/controller-manager-service.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-service.yaml
@@ -11,12 +11,12 @@ metadata:
 spec:
   type: {{ .Values.controllerManager.service.type }}
   ports:
-#    - port: {{ .Values.controllerManager.service.port }}
-#      targetPort: http
-#      protocol: TCP
-#      name: http
+    - port: 8080
+      targetPort: http
+      protocol: TCP
+      name: http
     - port: 443
-      targetPort: 9443
+      targetPort: webhook
       protocol: TCP
       name: webhook
   selector:

--- a/helm/chaos-mesh/templates/controller-manager-service.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-service.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: {{ .Values.controllerManager.service.type }}
   ports:
-    - port: 8080
+    - port: 10080
       targetPort: http
       protocol: TCP
       name: http

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -23,7 +23,6 @@ controllerManager:
 
   service:
     type: ClusterIP
-    port: 10080
 
   resources:
     # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

### What is changed and how does it work?

This is a prerequisite of adding Prometheus to chaos-mesh. Exposing 8080 in chaos controller-manager enables Prometheus to get metrics from controller-manager.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Change controller-manager default metrics port to 10080
```
