### PR TITLE
Correct minikube restriction: sch_netem is loaded by default in v1.6.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ You can try Chaos Mesh on your local K8s environment deployed using `kind` or `m
 
 There are some known restrictions for Chaos Operator deployed on `minikube` clusters:
 
-- `netem chaos` is not supported for `minikube` clusters.
+- `netem chaos` is only supported for `minikube` clusters >= version 1.6.
 
-    In `minikube`, the default virtual machine driver's image doesn't contain the `sch_netem` kernel module. You can use `none` driver (if your host is Linux with the `sch_netem` kernel module loaded) to try these chaos actions on `minikube` or [build an image with sch_netem by yourself](https://minikube.sigs.k8s.io/docs/contributing/iso/).
+    In `minikube`, the default virtual machine driver's image doesn't contain the `sch_netem` kernel module in smaller versions. You can use `none` driver (if your host is Linux with the `sch_netem` kernel module loaded) to try these chaos actions on `minikube` or [build an image with sch_netem by yourself](https://minikube.sigs.k8s.io/docs/contributing/iso/).
 
 ### Deploy target cluster
 


### PR DESCRIPTION
Signed-off-by: Laura Henning <laura-marie.henning@stud.h-da.de>

### What problem does this PR solve?
The restrictions for minikube are not up to date: netem related chaos can be run in default minikube vm in versions >= 1.6 now

### What is changed and how does it work?
I did a PR to minikube to make a tool called pumba work, which also uses tc netem. I noticed the kernel module was missing, and minikube guys accepted my PR to add it :)

This is just a change to the README of this project, so I ran no additional tests.