### PR TITLE
support docker mirror in install.sh

### DIFF
--- a/doc/get_started_on_kind.md
+++ b/doc/get_started_on_kind.md
@@ -19,7 +19,7 @@ cd chaos-mesh/
 ./install.sh --local kind
 ```
 
-`install.sh` is an automation shell script that helps you install dependencies such as `kubelet`, `Helm`, `kind`, and `kubernetes`, and `Chaos Mesh` itself.
+`install.sh` is an automation shell script that helps you install dependencies such as `kubectl`, `Helm`, `kind`, and `kubernetes`, and `Chaos Mesh` itself.
 
 After executing the above command, you should be able to see the prompt that Chaos Mesh is installed successfully. 
 Otherwise, please check the current environment according to the prompt message or send us an [issue](https://github.com/pingcap/chaos-mesh/issues) for help. 

--- a/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
+++ b/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: {{ .Values.controllerManager.serviceAccount }}
       containers:
         - name: "{{ .Release.Name }}-job-certs"
-          image: bitnami/kubectl:latest
+          image: {{ .Values.kubectlImage }}
           imagePullPolicy: IfNotPresent
           command:
             - "sh"

--- a/helm/chaos-mesh/templates/post-install-webhook-job.yaml
+++ b/helm/chaos-mesh/templates/post-install-webhook-job.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: {{ .Values.controllerManager.serviceAccount }}
       containers:
         - name: "{{ .Release.Name }}-job-mw"
-          image: bitnami/kubectl:latest
+          image: {{ .Values.kubectlImage }}
           imagePullPolicy: IfNotPresent
           command:
             - "sh"

--- a/helm/chaos-mesh/templates/pre-delete-job.yaml
+++ b/helm/chaos-mesh/templates/pre-delete-job.yaml
@@ -28,7 +28,7 @@ spec:
       serviceAccountName: {{ .Values.controllerManager.serviceAccount }}
       containers:
         - name: "{{.Release.Name}}-job-del"
-          image: bitnami/kubectl:latest
+          image: {{ .Values.kubectlImage }}
           imagePullPolicy: IfNotPresent
           command:
             - "sh"

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -13,6 +13,9 @@ rbac:
 # enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon.
 enableProfiling: false
 
+
+kubectlImage: bitnami/kubectl:latest
+
 controllerManager:
   serviceAccount: chaos-controller-manager
 

--- a/install.sh
+++ b/install.sh
@@ -506,7 +506,7 @@ install_helm() {
     local target_os=$(lowercase $(uname))
     local TAR_NAME="helm-$1-$target_os-amd64.tar.gz"
     rm -rf "${TAR_NAME}"
-    ensure curl -sL "https://get.helm.sh/${TAR_NAME}" | tar xz
+    ensure $(curl -sL "https://get.helm.sh/${TAR_NAME}" | tar xz)
 
     ensure mv "${target_os}"-amd64/helm "${HELM_BIN}"
     ensure chmod +x "${HELM_BIN}"


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

use docker mirror to pull the image in install.sh

### Check List <!--REMOVE the items that are not applicable-->


 - Manual test (add detailed scripts or steps below) 

```
./install.sh --local kind --docker-mirror 
``` 

output: 
```
chaos-mesh:chaos-controller-manager  27s

==> v1beta1/MutatingWebhookConfiguration
NAME                         AGE
chaos-mesh-sidecar-injector  27s

==> v1beta1/ValidatingWebhookConfiguration
NAME                   AGE
chaos-mesh-validation  27s


NOTES:
1. Make sure chaos-mesh components are running
   kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh

Chaos Mesh chaos-mesh is installed successfully
```
 