### PR TITLE
Reduce the number of kind nodes to 3

### DIFF
--- a/examples/web-show/deploy.sh
+++ b/examples/web-show/deploy.sh
@@ -51,7 +51,7 @@ kubectl apply -f deployment-target.yaml
 
 rm -rf deployment-target.yaml
 
-while [[ $(kubectl get pods -l app=web-show -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "Waiting for pod running" && sleep 1; done
+while [[ $(kubectl get pods -l app=web-show -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "Waiting for pod running" && sleep 10; done
 
 kill $(lsof -t -i:8081) >/dev/null 2>&1 || true
 

--- a/install.sh
+++ b/install.sh
@@ -31,7 +31,7 @@ OPTIONS:
                              If this value is not set and the Kubernetes is not installed, this script will exit with 1.
     -n, --name               Name of Kubernetes cluster, default value: kind
         --kind-version       Version of the Kind tool, default value: v0.7.0
-        --node-num           The count of the cluster nodes,default value: 5
+        --node-num           The count of the cluster nodes,default value: 3
         --k8s-version        Version of the Kubernetes cluster,default value: v1.17.2
         --volume-num         The volumes number of each kubernetes node,default value: 5
         --helm-version       Version of the helm tool, default value: v3.1.0
@@ -45,7 +45,7 @@ main() {
     local cm_version="latest"
     local kind_name="kind"
     local kind_version="v0.7.0"
-    local node_num=5
+    local node_num=3
     local k8s_version="v1.17.2"
     local volume_num=5
     local helm_version="v3.1.0"
@@ -355,7 +355,7 @@ EOF
     fi
 
     printf "start to create kubernetes cluster %s" "${cluster_name}"
-    ensure kind create cluster --config "${config_file}" --image="${kind_image}" --name="${cluster_name}"
+    ensure kind create cluster --config "${config_file}" --image="${kind_image}" --name="${cluster_name}" --retain -v 1
     ensure kind get kubeconfig --name="${cluster_name}" > "${kubeconfig_path}"
     ensure export KUBECONFIG="${kubeconfig_path}"
 


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists--> 

Kind failed to create a cluster with 
```
ERROR: failed to create cluster: failed to generate kubeadm config content: failed to get kubernetes version from node: failed to get file: command "docker exec --privileged kind-worker4 cat /kind/version" fa
iled with error: exit status 1

Output:
Error response from daemon: Container 46030848638d5695df3b1184d77fcb8502a1241548d2e9e8108201da6a3e11e7 is not running

Stack Trace:
sigs.k8s.io/kind/pkg/errors.WithStack
        /src/pkg/errors/errors.go:51
sigs.k8s.io/kind/pkg/exec.(*LocalCmd).Run
        /src/pkg/exec/local.go:116
sigs.k8s.io/kind/pkg/cluster/internal/providers/docker.(*nodeCmd).Run
        /src/pkg/cluster/internal/providers/docker/node.go:130
sigs.k8s.io/kind/pkg/exec.CombinedOutputLines
        /src/pkg/exec/helpers.go:67
sigs.k8s.io/kind/pkg/cluster/nodeutils.KubeVersion
        /src/pkg/cluster/nodeutils/util.go:58
sigs.k8s.io/kind/pkg/cluster/internal/create/actions/config.getKubeadmConfig
        /src/pkg/cluster/internal/create/actions/config/config.go:172
sigs.k8s.io/kind/pkg/cluster/internal/create/actions/config.(*Action).Execute.func1.1
        /src/pkg/cluster/internal/create/actions/config/config.go:84
sigs.k8s.io/kind/pkg/errors.UntilErrorConcurrent.func1
        /src/pkg/errors/concurrent.go:30
runtime.goexit
        /usr/local/go/src/runtime/asm_amd64.s:1357
```
### What is changed and how does it work?  

reduce the number of the kind node to 3

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
