### PR TITLE
Use the `pause` image to inject pod-failure chaos

### DIFF
--- a/controllers/podchaos/podfailure/types.go
+++ b/controllers/podchaos/podfailure/types.go
@@ -38,8 +38,9 @@ import (
 )
 
 const (
-	// fakeImage is a not-existing image.
-	fakeImage = "pingcap.com/fake-chaos-mesh:latest"
+
+	// Always fails a container
+	pauseImage = "gcr.io/google-containers/pause:latest"
 
 	podFailureActionMsg = "pause pod duration %s"
 )
@@ -217,7 +218,7 @@ func (r *Reconciler) failPod(ctx context.Context, pod *v1.Pod, podchaos *v1alpha
 			continue
 		}
 		pod.Annotations[key] = originImage
-		pod.Spec.InitContainers[index].Image = fakeImage
+		pod.Spec.InitContainers[index].Image = pauseImage
 	}
 
 	for index := range pod.Spec.Containers {
@@ -234,7 +235,7 @@ func (r *Reconciler) failPod(ctx context.Context, pod *v1.Pod, podchaos *v1alpha
 			continue
 		}
 		pod.Annotations[key] = originImage
-		pod.Spec.Containers[index].Image = fakeImage
+		pod.Spec.Containers[index].Image = pauseImage
 	}
 
 	if err := r.Update(ctx, pod); err != nil {


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->
Fix #189 
### What is changed and how does it work?
The `pause` image will always fail to start. 
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Code changes

 - Has Go code change

Side effects

 - No

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Use the `pause` image to inject pod-failure chaos
```
