### PR TITLE
Edit chaos-daemon DaemonSet to allow Tolerations

### DIFF
--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -38,7 +38,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `chaosDaemon.podAnnotations` | Pod annotations of chaos-daemon | `{}` |
 | `chaosDaemon.runtime` | Runtime specifies which container runtime to use. Currently we only supports docker and containerd. | `docker` |
 | `chaosDaemon.socketPath` | Specifies the container runtime socket | `/var/run/docker.sock` |
-| `chaosDaemon.`tolerations` | Toleration labels for chaos-daemon pod assignment | `[]` |
+| `chaosDaemon.tolerations` | Toleration labels for chaos-daemon pod assignment | `[]` |
 | `dashboard.create` | Enable chaos-dashboard | `false` |
 | `dashboard.serviceAccount` | The serviceAccount for chaos-dashboard  | `chaos-dashboard` |
 | `dashboard.image` | Docker image for chaos-dashboard | `pingcap/chaos-dashboard:latest` |

--- a/helm/chaos-mesh/README.md
+++ b/helm/chaos-mesh/README.md
@@ -38,6 +38,7 @@ The following tables list the configurable parameters of the Chaos Mesh chart an
 | `chaosDaemon.podAnnotations` | Pod annotations of chaos-daemon | `{}` |
 | `chaosDaemon.runtime` | Runtime specifies which container runtime to use. Currently we only supports docker and containerd. | `docker` |
 | `chaosDaemon.socketPath` | Specifies the container runtime socket | `/var/run/docker.sock` |
+| `chaosDaemon.`tolerations` | Toleration labels for chaos-daemon pod assignment | `[]` |
 | `dashboard.create` | Enable chaos-dashboard | `false` |
 | `dashboard.serviceAccount` | The serviceAccount for chaos-dashboard  | `chaos-dashboard` |
 | `dashboard.image` | Docker image for chaos-dashboard | `pingcap/chaos-dashboard:latest` |

--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -64,6 +64,10 @@ spec:
               hostPort: {{ .Values.chaosDaemon.grpcPort }}
             - name: http
               containerPort: {{ .Values.chaosDaemon.httpPort }}
+      {{- with .Values.chaosDaemon.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
       volumes:
         - name: socket-path
           hostPath:

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -70,6 +70,8 @@ chaosDaemon:
   # runtime: containerd
   # socketPath: /run/containerd/containerd.sock
 
+  tolerations: []
+
 dashboard:
   create: false
 


### PR DESCRIPTION
### What problem does this PR solve? 

In some Kubernetes configuration chaos-daemon DaemonSet default behaviour is not allowed to create pod on each kubernetes node.

### What is changed and how does it work?

Being able to use tolerations for chaos-daemon in chart values.yaml.

### Does this PR introduce a user-facing change?:

```release-note
Allow users to configure tolerations for chaos-daemon.
```