### PR TITLE
[WIP]remove the dependence on concrete chaos struct from validation pkg and add validation for KernelChaos

### DIFF
--- a/api/v1alpha1/common_types.go
+++ b/api/v1alpha1/common_types.go
@@ -15,7 +15,6 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // SelectorSpec defines the some selectors to select objects.
@@ -135,13 +134,3 @@ type ExperimentStatus struct {
 const (
 	invalidConfigurationMsg = "invalid configuration"
 )
-
-var log = ctrl.Log.WithName("validate-webhook")
-
-// +kubebuilder:object:generate=false
-
-// Admission describe the interface should be implemented in admission webhook
-type Admission interface {
-	// Validate describe the interface should be implemented in validation webhook
-	Validate() (bool, string, error)
-}

--- a/api/v1alpha1/kernelchaos_types.go
+++ b/api/v1alpha1/kernelchaos_types.go
@@ -211,6 +211,17 @@ func (in *KernelChaos) IsDeleted() bool {
 	return !in.DeletionTimestamp.IsZero()
 }
 
+// Validate implements Validator interface and describes the kernelchaos validation logic.
+func (in *KernelChaos) Validate() (bool, string, error) {
+	if in.Spec.Duration != nil && in.Spec.Scheduler != nil {
+		return true, "", nil
+	} else if in.Spec.Duration == nil && in.Spec.Scheduler == nil {
+		return true, "", nil
+	}
+
+	return false, invalidConfigurationMsg, nil
+}
+
 // +kubebuilder:object:root=true
 
 // KernelChaosList contains a list of KernelChaos

--- a/api/v1alpha1/networkchaos_types.go
+++ b/api/v1alpha1/networkchaos_types.go
@@ -244,7 +244,7 @@ func (in *NetworkChaos) GetScheduler() *SchedulerSpec {
 	return in.Spec.Scheduler
 }
 
-// Validate describe the network validation logic
+// Validate describes the network validation logic
 func (in *NetworkChaos) Validate() (bool, string, error) {
 	if in.Spec.Duration != nil && in.Spec.Scheduler != nil {
 		return true, "", nil

--- a/api/v1alpha1/podchaos_types.go
+++ b/api/v1alpha1/podchaos_types.go
@@ -201,7 +201,6 @@ func (in *PodChaos) Validate() (bool, string, error) {
 		return true, "", nil
 	default:
 		err := fmt.Errorf("podchaos[%s/%s] have unknown action type", in.Namespace, in.Name)
-		log.Error(err, "Wrong PodChaos Action type")
 		return false, err.Error(), err
 	}
 }

--- a/api/v1alpha1/validate.go
+++ b/api/v1alpha1/validate.go
@@ -1,0 +1,52 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// +kubebuilder:object:generate=false
+
+// Validator describes the interface should be implemented in validation webhook
+type Validator interface {
+	// Validate describe the interface should be implemented in validation webhook
+	Validate() (bool, string, error)
+}
+
+func ParseValidator(data []byte, kind string) (Validator, error) {
+	var validator Validator
+
+	switch kind {
+	case "PodChaos":
+		validator = &PodChaos{}
+	case "NetworkChaos":
+		validator = &NetworkChaos{}
+	case "IoChaos":
+		validator = &IoChaos{}
+	case "TimeChaos":
+		validator = &TimeChaos{}
+	case "KernelChaos":
+		validator = &KernelChaos{}
+	default:
+		return nil, fmt.Errorf("%s validator is not supported", kind)
+	}
+
+	if err := json.Unmarshal(data, validator); err != nil {
+		return nil, err
+	}
+
+	return validator, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae // indirect
-	golang.org/x/tools v0.0.0-20200305224536-de023d59a5d1
+	golang.org/x/tools v0.0.0-20200309202150-20ab64c0d93f
 	google.golang.org/genproto v0.0.0-20191028173616-919d9bdd9fe6 // indirect
 	google.golang.org/grpc v1.27.0
 	k8s.io/api v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -606,6 +606,8 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200221224223-e1da425f72fd/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200305224536-de023d59a5d1 h1:A6Mu2vcvuNXbBiGKuVHG74fmEPmzsZ5dzG0WhV2GcqI=
 golang.org/x/tools v0.0.0-20200305224536-de023d59a5d1/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
+golang.org/x/tools v0.0.0-20200309202150-20ab64c0d93f h1:NbrfHxef+IfdI86qCgO/1Siq1BuMH2xG0NqgvCguRhQ=
+golang.org/x/tools v0.0.0-20200309202150-20ab64c0d93f/go.mod h1:o4KQGtdN14AW+yjsvvwRTJJuXz8XRtIHtEnmAXLyFUw=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

* Fix #291 
* add validation for KernelChaos 

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
