### PR TITLE
netm: Add Netem as new action for applying delay, loss etc. at same time

### DIFF
--- a/config/crd/bases/pingcap.com_networkchaos.yaml
+++ b/config/crd/bases/pingcap.com_networkchaos.yaml
@@ -36,7 +36,8 @@ spec:
           properties:
             action:
               description: 'Action defines the specific network chaos action. Supported
-                action: delay Default action: delay'
+                action: partition, netem, delay, loss, duplicate, corrupt Default
+                action: delay'
               type: string
             corrupt:
               description: Corrupt represents the detail about corrupt action

--- a/controllers/networkchaos/netem/types.go
+++ b/controllers/networkchaos/netem/types.go
@@ -306,7 +306,7 @@ func mergeNetem(spec v1alpha1.NetworkChaosSpec) (*pb.Netem, error) {
 		if err != nil {
 			return nil, err
 		}
-		utils.MergeNetem(merged, em)
+		merged = utils.MergeNetem(merged, em)
 	}
 	return merged, nil
 }

--- a/controllers/networkchaos/netem/types_test.go
+++ b/controllers/networkchaos/netem/types_test.go
@@ -3,18 +3,52 @@ package netem
 import (
 	"testing"
 
+	. "github.com/onsi/gomega"
+
 	"github.com/pingcap/chaos-mesh/api/v1alpha1"
+
+	chaosdaemonpb "github.com/pingcap/chaos-mesh/pkg/chaosdaemon/pb"
 )
 
 func TestMergenetem(t *testing.T) {
-	spec := v1alpha1.NetworkChaosSpec{
-		Action: "netem",
-	}
-	_, err := mergeNetem(spec)
-	if err == nil {
-		t.Errorf("expect invalid spec failed with message %s but got nil", invalidNetemSpecMsg)
-	}
-	if err != nil && err.Error() != invalidNetemSpecMsg {
-		t.Errorf("expect merge failed with message %s but got %v", invalidNetemSpecMsg, err)
-	}
+
+	t.Run("empty", func(t *testing.T) {
+		spec := v1alpha1.NetworkChaosSpec{
+			Action: "netem",
+		}
+		_, err := mergeNetem(spec)
+		if err == nil {
+			t.Errorf("expect invalid spec failed with message %s but got nil", invalidNetemSpecMsg)
+		}
+		if err != nil && err.Error() != invalidNetemSpecMsg {
+			t.Errorf("expect merge failed with message %s but got %v", invalidNetemSpecMsg, err)
+		}
+	})
+
+	t.Run("delay loss", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+
+		spec := v1alpha1.NetworkChaosSpec{
+			Action: "netem",
+			Delay: &v1alpha1.DelaySpec{
+				Latency:     "90ms",
+				Correlation: "25",
+				Jitter:      "90ms",
+			},
+			Loss: &v1alpha1.LossSpec{
+				Loss:        "25",
+				Correlation: "25",
+			},
+		}
+		m, err := mergeNetem(spec)
+		g.Expect(err).ShouldNot(HaveOccurred())
+		em := &chaosdaemonpb.Netem{
+			Time:      90000,
+			Jitter:    90000,
+			DelayCorr: 25,
+			Loss:      25,
+			LossCorr:  25,
+		}
+		g.Expect(m).Should(Equal(em))
+	})
 }

--- a/controllers/networkchaos/netem/types_test.go
+++ b/controllers/networkchaos/netem/types_test.go
@@ -1,0 +1,20 @@
+package netem
+
+import (
+	"testing"
+
+	"github.com/pingcap/chaos-mesh/api/v1alpha1"
+)
+
+func TestMergenetem(t *testing.T) {
+	spec := v1alpha1.NetworkChaosSpec{
+		Action: "netem",
+	}
+	_, err := mergeNetem(spec)
+	if err == nil {
+		t.Errorf("expect invalid spec failed with message %s but got nil", invalidNetemSpecMsg)
+	}
+	if err != nil && err.Error() != invalidNetemSpecMsg {
+		t.Errorf("expect merge failed with message %s but got %v", invalidNetemSpecMsg, err)
+	}
+}

--- a/controllers/networkchaos/types.go
+++ b/controllers/networkchaos/types.go
@@ -60,7 +60,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request, chaos *v1alpha1.NetworkChaos) (
 func (r *Reconciler) commonNetworkChaos(networkchaos *v1alpha1.NetworkChaos, req ctrl.Request) (ctrl.Result, error) {
 	var cr *common.Reconciler
 	switch networkchaos.Spec.Action {
-	case v1alpha1.DelayAction, v1alpha1.DuplicateAction, v1alpha1.CorruptAction, v1alpha1.LossAction:
+	case v1alpha1.NetemAction, v1alpha1.DelayAction, v1alpha1.DuplicateAction, v1alpha1.CorruptAction, v1alpha1.LossAction:
 		cr = netem.NewCommonReconciler(r.Client, r.Log.WithValues("action", "netem"),
 			req, r.EventRecorder)
 	case v1alpha1.PartitionAction:
@@ -75,7 +75,7 @@ func (r *Reconciler) commonNetworkChaos(networkchaos *v1alpha1.NetworkChaos, req
 func (r *Reconciler) scheduleNetworkChaos(networkchaos *v1alpha1.NetworkChaos, req ctrl.Request) (ctrl.Result, error) {
 	var sr *twophase.Reconciler
 	switch networkchaos.Spec.Action {
-	case v1alpha1.DelayAction, v1alpha1.DuplicateAction, v1alpha1.CorruptAction, v1alpha1.LossAction:
+	case v1alpha1.NetemAction, v1alpha1.DelayAction, v1alpha1.DuplicateAction, v1alpha1.CorruptAction, v1alpha1.LossAction:
 		sr = netem.NewTwoPhaseReconciler(r.Client, r.Log.WithValues("action", "netem"),
 			req, r.EventRecorder)
 	case v1alpha1.PartitionAction:

--- a/controllers/networkchaos_controller_test.go
+++ b/controllers/networkchaos_controller_test.go
@@ -28,6 +28,7 @@ import (
 
 var _ = Describe("NetworkChaos Controller", func() {
 	supportingModes := []v1alpha1.NetworkChaosAction{
+		v1alpha1.NetemAction,
 		v1alpha1.DelayAction,
 		v1alpha1.LossAction,
 		v1alpha1.DuplicateAction,

--- a/controllers/twophase/types.go
+++ b/controllers/twophase/types.go
@@ -128,6 +128,12 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		}
 
 		nextRecover := now.Add(*duration)
+		// TODO(at15): this should be validated in webhook instead of throwing error at runtime.
+		// User can give a cron with interval shorter than duration.
+		// Example:
+		//  duration: "10s"
+		//  scheduler:
+		//    cron: "@every 5s
 		if nextStart.Before(nextRecover) {
 			err := fmt.Errorf("nextRecover shouldn't be later than nextStart")
 			r.Log.Error(err, "nextRecover is later than nextStart. Then recover can never be reached",

--- a/examples/network-netem-example.yaml
+++ b/examples/network-netem-example.yaml
@@ -1,0 +1,21 @@
+apiVersion: pingcap.com/v1alpha1
+kind: NetworkChaos
+metadata:
+  name: network-netem-example
+  namespace: chaos-testing
+spec:
+  action: netem
+  mode: one
+  selector:
+    labelSelectors:
+      "app.kubernetes.io/component": "tikv"
+  delay:
+    latency: "90ms"
+    correlation: "25"
+    jitter: "90ms"
+  loss:
+    loss: "25"
+    correlation: "25"
+  duration: "10s"
+  scheduler:
+    cron: "@every 15s"

--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -548,7 +548,8 @@ spec:
           properties:
             action:
               description: 'Action defines the specific network chaos action. Supported
-                action: delay Default action: delay'
+                action: partition, netem, delay, loss, duplicate, corrupt Default
+                action: delay'
               type: string
             corrupt:
               description: Corrupt represents the detail about corrupt action

--- a/pkg/chaosdaemon/util.go
+++ b/pkg/chaosdaemon/util.go
@@ -24,13 +24,12 @@ import (
 	"sync"
 	"syscall"
 
-	"github.com/pingcap/chaos-mesh/pkg/utils"
-
 	"github.com/containerd/containerd"
 	"github.com/docker/docker/api/types"
 	dockerclient "github.com/docker/docker/client"
 
 	"github.com/pingcap/chaos-mesh/pkg/mock"
+	"github.com/pingcap/chaos-mesh/pkg/utils"
 )
 
 const (

--- a/pkg/utils/chaosdaemon.go
+++ b/pkg/utils/chaosdaemon.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"math"
 
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
@@ -44,4 +45,49 @@ func NewChaosDaemonClient(ctx context.Context, c client.Client, pod *v1.Pod, por
 		ChaosDaemonClient: chaosdaemon.NewChaosDaemonClient(cc),
 		conn:              cc,
 	}, nil
+}
+
+// MergeNetem merges two Netem protos.
+// For each field it takes the bigger value of the two.
+// Its main use case is merging netem of different types, e.g. delay and loss.
+// It returns nil if both inputs are nil.
+// Otherwise it returns a new Netem with merged values.
+func MergeNetem(a, b *chaosdaemon.Netem) *chaosdaemon.Netem {
+	if a == nil && b == nil {
+		return nil
+	}
+	// NOTE: because proto getters check nil, we are good here even if one of them is nil.
+	// But we just assign empty value to make IDE and linters happy.
+	if a == nil {
+		a = &chaosdaemon.Netem{}
+	}
+	if b == nil {
+		b = &chaosdaemon.Netem{}
+	}
+	return &chaosdaemon.Netem{
+		Time:          maxu32(a.GetTime(), b.GetTime()),
+		Jitter:        maxu32(a.GetJitter(), b.GetJitter()),
+		DelayCorr:     maxf32(a.GetDelayCorr(), b.GetDelayCorr()),
+		Limit:         maxu32(a.GetLimit(), b.GetLimit()),
+		Loss:          maxf32(a.GetLoss(), b.GetLoss()),
+		LossCorr:      maxf32(a.GetLossCorr(), b.GetLossCorr()),
+		Gap:           maxu32(a.GetGap(), b.GetGap()),
+		Duplicate:     maxf32(a.GetDuplicate(), b.GetDuplicate()),
+		DuplicateCorr: maxf32(a.GetDuplicateCorr(), b.GetDuplicateCorr()),
+		Reorder:       maxf32(a.GetReorder(), b.GetReorder()),
+		ReorderCorr:   maxf32(a.GetReorderCorr(), b.GetReorderCorr()),
+		Corrupt:       maxf32(a.GetCorrupt(), b.GetCorrupt()),
+		CorruptCorr:   maxf32(a.GetCorruptCorr(), b.GetCorruptCorr()),
+	}
+}
+
+func maxu32(a, b uint32) uint32 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func maxf32(a, b float32) float32 {
+	return float32(math.Max(float64(a), float64(b)))
 }

--- a/pkg/utils/chaosdaemon.go
+++ b/pkg/utils/chaosdaemon.go
@@ -47,7 +47,8 @@ func NewChaosDaemonClient(ctx context.Context, c client.Client, pod *v1.Pod, por
 	}, nil
 }
 
-// MergeNetem merges two Netem protos.
+// MergeNetem merges two Netem protos into a new one.
+// REMEMBER to assign the return value, i.e. merged = utils.MergeNetm(merged, em)
 // For each field it takes the bigger value of the two.
 // Its main use case is merging netem of different types, e.g. delay and loss.
 // It returns nil if both inputs are nil.

--- a/pkg/utils/chaosdaemon_test.go
+++ b/pkg/utils/chaosdaemon_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	chaosdaemonpb "github.com/pingcap/chaos-mesh/pkg/chaosdaemon/pb"
+)
+
+func TestMergeNetem(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cases := []struct {
+		a      *chaosdaemonpb.Netem
+		b      *chaosdaemonpb.Netem
+		merged *chaosdaemonpb.Netem
+	}{
+		{nil, nil, nil}, // nil, nil -> nil
+		{
+			// no conflict
+			&chaosdaemonpb.Netem{Loss: 25},
+			&chaosdaemonpb.Netem{DelayCorr: 90},
+			&chaosdaemonpb.Netem{Loss: 25, DelayCorr: 90},
+		},
+		{
+			// pick the max
+			&chaosdaemonpb.Netem{Loss: 25, DelayCorr: 100.2},
+			&chaosdaemonpb.Netem{DelayCorr: 90},
+			&chaosdaemonpb.Netem{Loss: 25, DelayCorr: 100.2},
+		},
+	}
+
+	for _, tc := range cases {
+		m := MergeNetem(tc.a, tc.b)
+		g.Expect(tc.merged).Should(Equal(m))
+	}
+}


### PR DESCRIPTION
UCP #345 

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix #345 

### What is changed and how does it work?

Add a new action called `netem` for networkchaos, when provided, the controller will merge all individual specs (delay, loss etc.) into one `Netem` RPC request.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - [ ] Unit test, seem we don't have any ... #263 
 - [ ] E2E test, it's WIP #322 
 - [x] Manual test (add detailed scripts or steps below) blocked by #352 

Code changes

 - Has Go code change

Side effects

 - [ ] Breaking backward compatibility (depends on how we want impl it ...)

Related changes

 - [ ] Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Add netem as new network chaos action. It supports applying delay, loss etc. at same time.
```
