### PR TITLE
Add default value for `caBundle` field

### DIFF
--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -15,7 +15,7 @@ Options:
        -n,--name               name of the Kubernetes cluster,default value: kind
        -c,--nodeNum            the count of the cluster nodes,default value: 3
        -k,--k8sVersion         version of the Kubernetes cluster,default value: v1.17.2
-       -v,--volumeNum          the volumes number of each kubernetes node,default value: 3
+       -v,--volumeNum          the volumes number of each kubernetes node,default value: 5
 Usage:
     $0 --name testCluster --nodeNum 4 --k8sVersion v1.17.2
 EOF
@@ -61,7 +61,7 @@ done
 clusterName=${clusterName:-kind}
 nodeNum=${nodeNum:-3}
 k8sVersion=${k8sVersion:-v1.17.2}
-volumeNum=${volumeNum:-3}
+volumeNum=${volumeNum:-5}
 
 echo "clusterName: ${clusterName}"
 echo "nodeNum: ${nodeNum}"

--- a/hack/kind-cluster-build.sh
+++ b/hack/kind-cluster-build.sh
@@ -13,11 +13,11 @@ Before run this script,please ensure that:
 Options:
        -h,--help               prints the usage message
        -n,--name               name of the Kubernetes cluster,default value: kind
-       -c,--nodeNum            the count of the cluster nodes,default value: 6
-       -k,--k8sVersion         version of the Kubernetes cluster,default value: v1.12.8
-       -v,--volumeNum          the volumes number of each kubernetes node,default value: 9
+       -c,--nodeNum            the count of the cluster nodes,default value: 3
+       -k,--k8sVersion         version of the Kubernetes cluster,default value: v1.17.2
+       -v,--volumeNum          the volumes number of each kubernetes node,default value: 3
 Usage:
-    $0 --name testCluster --nodeNum 4 --k8sVersion v1.12.9
+    $0 --name testCluster --nodeNum 4 --k8sVersion v1.17.2
 EOF
 }
 
@@ -59,9 +59,9 @@ esac
 done
 
 clusterName=${clusterName:-kind}
-nodeNum=${nodeNum:-6}
-k8sVersion=${k8sVersion:-v1.12.8}
-volumeNum=${volumeNum:-9}
+nodeNum=${nodeNum:-3}
+k8sVersion=${k8sVersion:-v1.17.2}
+volumeNum=${volumeNum:-3}
 
 echo "clusterName: ${clusterName}"
 echo "nodeNum: ${nodeNum}"

--- a/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
+++ b/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
@@ -137,7 +137,4 @@ spec:
                       --from-file=tls.crt=${tmpdir}/server-cert.pem \
                       --dry-run -o yaml |
                   kubectl -n ${K8S_NAMESPACE} apply -f -
-
-              sleep 600
-
 {{- end }}

--- a/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
+++ b/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
@@ -42,9 +42,6 @@ spec:
               # test if secret already exists
               certs=$(kubectl get secret ${K8S_SECRET} --ignore-not-found -n ${K8S_NAMESPACE} -o name)
 
-              echo "get certs"
-              echo ${certs}
-
               if [ "${certs}" = "secret/${K8S_SECRET}" ];then
                 echo "Secret already exists"
                 exit 0
@@ -72,12 +69,8 @@ spec:
 
               openssl genrsa -out ${tmpdir}/server-key.pem 2048
 
-              echo "cat ${tmpdir}/server-key.pem"
-              cat ${tmpdir}/server-key.pem
-
               echo "generate csr"
               openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${K8S_SERVICE}.${K8S_NAMESPACE}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
-              cat ${tmpdir}/server-key.pem
 
               # clean-up any previously created CSR for our service. Ignore errors if not present.
               kubectl delete csr ${csrName} 2>/dev/null || true

--- a/helm/chaos-mesh/templates/webhook-configuration.yaml
+++ b/helm/chaos-mesh/templates/webhook-configuration.yaml
@@ -16,6 +16,7 @@ metadata:
 webhooks:
   - name: {{ template "chaos-mesh.webhook" . }}
     clientConfig:
+      caBundle: Cg==
       service:
         name: {{ template "chaos-mesh.svc" . }}
         namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix #352  

### What is changed and how does it work? 

* Add some debug log when to create certs 
* Add default value for  `caBundle` field, because we add Validator  and this field was marked as a required field in v1.12.8 Kubernetes  
* Update some default value in kind-create-cluster.sh 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)


Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
