### PR TITLE
[WIP] IOChaos: clean pidfile

### DIFF
--- a/doc/sidecar_configmap.md
+++ b/doc/sidecar_configmap.md
@@ -32,7 +32,7 @@ data:
     - name: inject-scripts
       image: pingcap/chaos-scripts:latest
       imagePullpolicy: Always
-      command: ["sh", "-c", "/scripts/init.sh -d /var/lib/tikv/data -f /var/lib/tikv/fuse-data"]
+      command: ["sh", "-c", "/scripts/init.sh -d /var/lib/tikv/data -f /var/lib/tikv/fuse-data -p /tmp/fuse/pid"]
     containers:
     - name: chaosfs
       image: pingcap/chaos-fs:latest
@@ -160,6 +160,7 @@ OPTIONS:
    -d <data directory>     Data directory of the application
    -f <fuse directory>     Data directory of the fuse original directory
    -s <scripts directory>  Scripts directory
+   -p <fuse pidfile>       Pidfile of fuse server
 EXAMPLES:
    init.sh -d /var/lib/tikv/data -f /var/lib/tikv/fuse-data
 ```

--- a/examples/chaosfs-configmap/pd-configmap.yaml
+++ b/examples/chaosfs-configmap/pd-configmap.yaml
@@ -16,7 +16,7 @@ data:
     - name: inject-scripts
       image: pingcap/chaos-scripts:latest
       imagePullpolicy: Always
-      command: ["sh", "-c", "/scripts/init.sh -d /var/lib/pd/data -f /var/lib/pd/fuse-data"]
+      command: ["sh", "-c", "/scripts/init.sh -d /var/lib/pd/data -f /var/lib/pd/fuse-data -p /tmp/fuse/pid"]
     containers:
     - name: chaosfs
       image: pingcap/chaos-fs:latest

--- a/examples/chaosfs-configmap/tiflash-configmap.yaml
+++ b/examples/chaosfs-configmap/tiflash-configmap.yaml
@@ -16,7 +16,7 @@ data:
     - name: inject-scripts
       image: pingcap/chaos-scripts:latest
       imagePullpolicy: Always
-      command: ["sh", "-c", "/scripts/init.sh -d /data/db -f /data/fuse-data"]
+      command: ["sh", "-c", "/scripts/init.sh -d /data/db -f /data/fuse-data -p /tmp/fuse/pid"]
     containers:
     - name: chaosfs
       image: pingcap/chaos-fs:latest

--- a/examples/chaosfs-configmap/tikv-configmap.yaml
+++ b/examples/chaosfs-configmap/tikv-configmap.yaml
@@ -16,7 +16,7 @@ data:
     - name: inject-scripts
       image: pingcap/chaos-scripts:latest
       imagePullpolicy: Always
-      command: ["sh", "-c", "/scripts/init.sh -d /var/lib/tikv/data -f /var/lib/tikv/fuse-data"]
+      command: ["sh", "-c", "/scripts/init.sh -d /var/lib/tikv/data -f /var/lib/tikv/fuse-data -p /tmp/fuse/pid"]
     containers:
     - name: chaosfs
       image: pingcap/chaos-fs:latest

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -5,16 +5,18 @@ set -eo pipefail
 DATADIR=""
 FUSEDIR=""
 SCRIPTSDIR="/tmp/scripts"
+PIDFILE="/tmp/fuse/pid"
 
 usage() {
 cat << EOF
 USAGE: $0 [-d data directory] [-f fuse directory]
 Used to do some preparation
 OPTIONS:
-   -h                      Show this message
-   -d <data directory>     Data directory of the application
-   -f <fuse directory>     Data directory of the fuse original directory
-   -s <scripts directory>  Scripts directory
+   -h                        Show this message
+   -d <data directory>       Data directory of the application
+   -f <fuse directory>       Data directory of the fuse original directory
+   -s <scripts directory>    Scripts directory
+   -p <fuse pidfile>         The pid file of fuse server
 EXAMPLES:
    init.sh -d /var/lib/tikv/data -f /var/lib/tikv/fuse-data
 EOF
@@ -26,6 +28,7 @@ do	case "$o" in
             exit 1;;
 	d)      DATADIR=$OPTARG;;
 	f)      FUSEDIR=$OPTARG;;
+	p)      PIDFILE=$OPTARG;;
 	[?])	usage
 		exit 1;;
 	esac
@@ -55,6 +58,11 @@ copy_scripts() {
 
   echo "cp -R /scripts/* ${1}/"
   cp -R /scripts/* ${1}/
+}
+
+clean_fuse_pidfile() {
+   echo "clean fuse pidfile ${1}"
+   rm -rf ${1}
 }
 
 copy_scripts ${SCRIPTSDIR}

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -68,3 +68,5 @@ clean_fuse_pidfile() {
 copy_scripts ${SCRIPTSDIR}
 
 mkdir_dir ${DATADIR} ${FUSEDIR}
+
+clean_fuse_pidfile ${PIDFILE}

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -22,7 +22,7 @@ EXAMPLES:
 EOF
 }
 
-while getopts h:d:f: o
+while getopts h:d:f:p: o
 do	case "$o" in
 	h)      usage
             exit 1;;


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists--> 

When to inject IOChaos, if the pod of the application was restarted, the `chaosfs` failed to start. 

```
Chaosfs Version: version.Info{GitVersion:"v0.0.0-master+$Format:%h$", GitCommit:"$Format:%H$", GitTreeState:"", BuildDate:"2020-03-24T05:43:30Z", GoVersion:"go1.13.8", Compiler:"gc", Platform:"linux/amd64"}
2020-03-25T06:25:58.567Z	INFO	chaos-daemon	Init hookfs
2020-03-25T06:25:58.567Z	ERROR	chaos-daemon	failed to create pid file	{"error": "pid file found, ensure docker is not running or delete /tmp/fuse/pid"}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
main.main
	/src/cmd/chaosfs/main.go:105
runtime.main
	/usr/local/go/src/runtime/proc.go:203
```

### What is changed and how does it work?

Remove the pidfile of  `chaosfs` in `init.sh`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
