### PR TITLE
remove scripts directory from `.dockerignore` file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,5 +10,4 @@ examples
 helm
 images
 manifests
-scripts
 static

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ image-chaos-mesh: image-binary
 image-chaos-fs: image-binary
 	docker build -t ${DOCKER_REGISTRY_PREFIX}pingcap/chaos-fs ${DOCKER_BUILD_ARGS} images/chaosfs
 
-image-chaos-scripts:
+image-chaos-scripts: image-binary
 	docker build -t ${DOCKER_REGISTRY_PREFIX}pingcap/chaos-scripts ${DOCKER_BUILD_ARGS} images/chaos-scripts
 
 image-chaos-grafana:


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

failed to exec 'make image-chaos-scripts ' 

```
Step 6/7 : COPY --from=pingcap/binary /src/scripts/wait-fuse.sh /scripts/wait-fuse.sh
COPY failed: stat /var/lib/docker/overlay2/2e42d7a975f8a02143a155d2a6214bf37ae142197651601117ac76668787f917/merged/src/scripts/wait-fuse.sh: no such file or directory
```

### What is changed and how does it work? 

remove scripts directory from `.dockerignore` file 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
