### PR TITLE
fix test unnamed results of the same type may be confusing warning

### DIFF
--- a/controllers/timechaos/types.go
+++ b/controllers/timechaos/types.go
@@ -304,9 +304,9 @@ func (r *Reconciler) applyContainer(ctx context.Context, client chaosdaemon.Chao
 	return err
 }
 
-func secAndNSecFromDuration(duration time.Duration) (int64, int64) {
-	sec := duration.Nanoseconds() / 1e9
-	nsec := duration.Nanoseconds() - (sec * 1e9)
+func secAndNSecFromDuration(duration time.Duration) (sec int64, nsec int64) {
+	sec = duration.Nanoseconds() / 1e9
+	nsec = duration.Nanoseconds() - (sec * 1e9)
 
-	return sec, nsec
+	return
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix warning during the tests 
```
/Users/vincent.huang/Go/bin/revive -formatter friendly -config revive.toml $(go list ./... | grep -vE "pkg/client" | grep -vE "zz_generated" | grep -vE "vendor")
  ⚠  https://revive.run/r#confusing-results  unnamed results of the same type may be confusing, consider using named results
  /Users/vincent.huang/Workspace/pingcap/chaos-mesh/controllers/timechaos/types.go:307:1

⚠ 1 problem (0 errors, 1 warning)

Warnings:
  1  confusing-results
```

### What is changed and how does it work?

add named results

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 

Code changes

 - Has Go code change

Side effects

n/a

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
