### PR TITLE
Set version of grafana image

### DIFF
--- a/images/grafana/Dockerfile
+++ b/images/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:master
+FROM grafana/grafana:6.7.1
 
 # enable anonymous
 COPY grafana.ini /etc/grafana


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve?

Set the concrete version of grafana image.

### What is changed and how does it work?

Use 6.7.1 grafana image. The good news is that both Prometheus and MySQL Datasource supports region annotations now.

This will also fix master CI build fail (because of the wrong architecture image) (by pulling a new image).
