### PR TITLE
Dynamically get kitware asc key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ image-chaos-dashboard: image-binary
 	docker build -t ${DOCKER_REGISTRY_PREFIX}pingcap/chaos-dashboard ${DOCKER_BUILD_ARGS} images/chaos-dashboard
 
 image-chaos-kernel:
-	docker build -t ${DOCKER_REGISTRY_PREFIX}pingcap/chaos-kernel ${DOCKER_BUILD_ARGS} --build-arg MAKE_JOBS=${MAKE_JOBS} images/chaos-kernel
+	docker build -t ${DOCKER_REGISTRY_PREFIX}pingcap/chaos-kernel ${DOCKER_BUILD_ARGS} --build-arg MAKE_JOBS=${MAKE_JOBS} --build-arg MIRROR=${UBUNTU_MIRROR} images/chaos-kernel
 
 docker-push:
 	docker push "${DOCKER_REGISTRY_PREFIX}pingcap/chaos-mesh:latest"

--- a/images/chaos-kernel/Dockerfile
+++ b/images/chaos-kernel/Dockerfile
@@ -3,24 +3,18 @@ FROM ubuntu:bionic
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
 ARG MAKE_JOBS
+ARG MIRROR=http://archive.ubuntu.com/ubuntu
 
-RUN apt update && apt install -y ca-certificates gnupg2
+RUN apt-get update && apt-get install -y ca-certificates gnupg2 wget
 
-RUN echo "deb https://mirrors.aliyun.com/ubuntu/ bionic main restricted universe multiverse\n"\
-    "deb https://mirrors.aliyun.com/ubuntu/ bionic-security main restricted universe multiverse\n"\
-    "deb https://mirrors.aliyun.com/ubuntu/ bionic-updates main restricted universe multiverse\n"\
-    "deb https://mirrors.aliyun.com/ubuntu/ bionic-proposed main restricted universe multiverse\n"\
-    "deb https://mirrors.aliyun.com/ubuntu/ bionic-backports main restricted universe multiverse\n"\
-    "deb-src https://mirrors.aliyun.com/ubuntu/ bionic main restricted universe multiverse\n"\
-    "deb-src https://mirrors.aliyun.com/ubuntu/ bionic-security main restricted universe multiverse\n"\
-    "deb-src https://mirrors.aliyun.com/ubuntu/ bionic-updates main restricted universe multiverse\n"\
-    "deb-src https://mirrors.aliyun.com/ubuntu/ bionic-proposed main restricted universe multiverse\n"\
-    "deb-src https://mirrors.aliyun.com/ubuntu/ bionic-backports main restricted universe multiverse\n"\
-    "deb https://apt.kitware.com/ubuntu/ bionic main" > /etc/apt/sources.list
+RUN sed -i "s|http://archive.ubuntu.com/ubuntu|$MIRROR|g" /etc/apt/sources.list
 
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 8611B7A28669BB93
+RUN echo "" >> /etc/apt/sources.list
+RUN echo "deb https://apt.kitware.com/ubuntu/ bionic main" >> /etc/apt/sources.list
 
-RUN apt update &&  apt install -y gcc-8 g++-8 bison build-essential \
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | apt-key add -
+
+RUN apt-get update &&  apt-get install -y gcc-8 g++-8 bison build-essential \
     flex git libedit-dev libllvm6.0 llvm-6.0-dev libclang-6.0-dev python python-pip \
     zlib1g-dev libelf-dev libssl-dev && pip install cmake==3.13.3
 


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix #392 

Another change is to use official ubuntu mirror default (rather than aliyun mirror). The source address can be controled by environment variable `UBUNTU_MIRROR`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

