### PR TITLE
Set mirrors only if not empty

### DIFF
--- a/images/chaos-kernel/Dockerfile
+++ b/images/chaos-kernel/Dockerfile
@@ -8,7 +8,6 @@ ARG MIRROR=http://archive.ubuntu.com/ubuntu
 RUN apt-get update && apt-get install -y ca-certificates gnupg2 wget
 
 RUN if [ ! -z "$MIRROR" ]; then sed -i "s|http://archive.ubuntu.com/ubuntu|$MIRROR|g" /etc/apt/sources.list; fi
-RUN cat /etc/apt/sources.list
 
 RUN echo "" >> /etc/apt/sources.list
 RUN echo "deb https://apt.kitware.com/ubuntu/ bionic main" >> /etc/apt/sources.list

--- a/images/chaos-kernel/Dockerfile
+++ b/images/chaos-kernel/Dockerfile
@@ -7,7 +7,8 @@ ARG MIRROR=http://archive.ubuntu.com/ubuntu
 
 RUN apt-get update && apt-get install -y ca-certificates gnupg2 wget
 
-RUN sed -i "s|http://archive.ubuntu.com/ubuntu|$MIRROR|g" /etc/apt/sources.list
+RUN if [ ! -z "$MIRROR" ]; then sed -i "s|http://archive.ubuntu.com/ubuntu|$MIRROR|g" /etc/apt/sources.list; fi
+RUN cat /etc/apt/sources.list
 
 RUN echo "" >> /etc/apt/sources.list
 RUN echo "deb https://apt.kitware.com/ubuntu/ bionic main" >> /etc/apt/sources.list


### PR DESCRIPTION
Signed-off-by: Yang Keao <keao.yang@yahoo.com>

### What problem does this PR solve? 

Makefile will pass empty MIRROR into Dockerfile, and this will override the default settings for ARG MIRROR.

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

