### PR TITLE
Add missing namespaces to helm templates

### DIFF
--- a/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
+++ b/helm/chaos-mesh/templates/chaos-daemon-daemonset.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-daemon
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/collector-mysql.yaml
+++ b/helm/chaos-mesh/templates/collector-mysql.yaml
@@ -3,6 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-collector-database
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -66,6 +67,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: mysql-initdb-config
 data:
   initdb.sql: |
@@ -92,6 +94,7 @@ data:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: collector-mysql-pv-claim
 spec:
   {{- if .Values.dashboard.volume.storageClassName }}
@@ -111,6 +114,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-collector-database
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/collector-rbac.yaml
+++ b/helm/chaos-mesh/templates/collector-rbac.yaml
@@ -4,6 +4,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.dashboard.serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -102,6 +103,7 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}:chaos-dashboard
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -143,6 +145,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}:chaos-dashboard
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/controller-manager-deployment.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-controller-manager
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/controller-manager-rbac.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-rbac.yaml
@@ -2,6 +2,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.controllerManager.serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -103,6 +104,7 @@ roleRef:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}:chaos-controller-manager
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -147,6 +149,7 @@ rules:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ .Release.Name }}:chaos-controller-manager
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/controller-manager-service.yaml
+++ b/helm/chaos-mesh/templates/controller-manager-service.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ template "chaos-mesh.svc" . }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/dashboard-deployment.yaml
+++ b/helm/chaos-mesh/templates/dashboard-deployment.yaml
@@ -3,6 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-dashboard
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -62,6 +63,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-dashboard
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
+++ b/helm/chaos-mesh/templates/post-install-create-cert-job.yaml
@@ -2,6 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: webhook-certs-job
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -81,6 +82,7 @@ spec:
               apiVersion: certificates.k8s.io/v1beta1
               kind: CertificateSigningRequest
               metadata:
+                namespace: {{ .Release.Namespace }}
                 name: ${csrName}
               spec:
                 groups:

--- a/helm/chaos-mesh/templates/post-install-webhook-job.yaml
+++ b/helm/chaos-mesh/templates/post-install-webhook-job.yaml
@@ -2,6 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: webhook-mw-job
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/pre-delete-job.yaml
+++ b/helm/chaos-mesh/templates/pre-delete-job.yaml
@@ -2,6 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: webhook-del
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/prometheus-configmap.yaml
+++ b/helm/chaos-mesh/templates/prometheus-configmap.yaml
@@ -2,6 +2,7 @@
 kind: ConfigMap
 apiVersion: v1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: prometheus-config
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/prometheus-deployment.yaml
+++ b/helm/chaos-mesh/templates/prometheus-deployment.yaml
@@ -3,6 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-prometheus
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}
@@ -84,6 +85,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: prometheus-pvc
 spec:
   {{- if .Values.prometheus.volume.storageClassName }}

--- a/helm/chaos-mesh/templates/prometheus-rbac.yaml
+++ b/helm/chaos-mesh/templates/prometheus-rbac.yaml
@@ -4,6 +4,7 @@
 kind: ServiceAccount
 apiVersion: v1
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: {{ .Values.prometheus.serviceAccount }}
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}

--- a/helm/chaos-mesh/templates/prometheus-service.yaml
+++ b/helm/chaos-mesh/templates/prometheus-service.yaml
@@ -3,6 +3,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: {{ .Release.Namespace }}
   name: chaos-prometheus
   labels:
     app.kubernetes.io/name: {{ template "chaos-mesh.name" . }}


### PR DESCRIPTION
Some (not all) helm charts were missing namespace values. These are
essential for applying templates after rendering them.

https://github.com/helm/helm/issues/5465#issuecomment-541358344

Signed-off-by: Robert Collins <robert.collins@cognite.com>

### What problem does this PR solve? 

(Some) rendered (helm template) templates don't have namespaces.

### What is changed and how does it work?

Added the namespace to namespace objects where missing.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - E2E test

Code changes
 - Has CI related scripts change

Side effects

Related changes

### Does this PR introduce a user-facing change?:

```release-note
NONE
```
