### PR TITLE
Use a global config to keep daemon ports

### DIFF
--- a/controllers/common/config.go
+++ b/controllers/common/config.go
@@ -1,18 +1,33 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import "os"
 
+// Cfg is a global variable to keep daemon ports
 var Cfg *Config
 
 func init() {
 	Cfg = NewConfig()
 }
-
+// Config is a struct for daemon ports config
 type Config struct {
 	ChaosDaemonPort string
 	BPFKIPort       string
 }
 
+// NewConfig returns a new Config
 func NewConfig() *Config {
 	return &Config{
 		ChaosDaemonPort: os.Getenv("CHAOS_DAEMON_PORT"),

--- a/controllers/common/config.go
+++ b/controllers/common/config.go
@@ -1,0 +1,21 @@
+package common
+
+import "os"
+
+var Cfg *Config
+
+func init() {
+	Cfg = NewConfig()
+}
+
+type Config struct {
+	ChaosDaemonPort string
+	BPFKIPort       string
+}
+
+func NewConfig() *Config {
+	return &Config{
+		ChaosDaemonPort: os.Getenv("CHAOS_DAEMON_PORT"),
+		BPFKIPort:       os.Getenv("BPFKI_PORT"),
+	}
+}

--- a/controllers/common/config.go
+++ b/controllers/common/config.go
@@ -21,6 +21,7 @@ var Cfg *Config
 func init() {
 	Cfg = NewConfig()
 }
+
 // Config is a struct for daemon ports config
 type Config struct {
 	ChaosDaemonPort string

--- a/controllers/kernelchaos/types.go
+++ b/controllers/kernelchaos/types.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	k8serror "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -182,7 +181,7 @@ func (r *Reconciler) cleanFinalizersAndRecover(ctx context.Context, chaos *v1alp
 func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.KernelChaos) error {
 	r.Log.Info("try to recover pod", "namespace", pod.Namespace, "name", pod.Name)
 
-	c1, err := utils.CreateGrpcConnection(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	c1, err := utils.CreateGrpcConnection(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -209,7 +208,7 @@ func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha
 		r.Log.Info("Get container pid", "namespace", pod.Namespace, "name", pod.Name)
 	}
 
-	c2, err := utils.CreateGrpcConnection(ctx, r.Client, pod, os.Getenv("BPFKI_PORT"))
+	c2, err := utils.CreateGrpcConnection(ctx, r.Client, pod, common.Cfg.BPFKIPort)
 	if err != nil {
 		return err
 	}
@@ -260,7 +259,7 @@ func (r *Reconciler) applyAllPods(ctx context.Context, pods []v1.Pod, chaos *v1a
 func (r *Reconciler) applyPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.KernelChaos) error {
 	r.Log.Info("Try to inject kernel on pod", "namespace", pod.Namespace, "name", pod.Name)
 
-	c1, err := utils.CreateGrpcConnection(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	c1, err := utils.CreateGrpcConnection(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -287,7 +286,7 @@ func (r *Reconciler) applyPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.
 		r.Log.Info("Get container pid", "namespace", pod.Namespace, "name", pod.Name)
 	}
 
-	c2, err := utils.CreateGrpcConnection(ctx, r.Client, pod, os.Getenv("BPFKI_PORT"))
+	c2, err := utils.CreateGrpcConnection(ctx, r.Client, pod, common.Cfg.BPFKIPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/networkchaos/ipset/ipset.go
+++ b/controllers/networkchaos/ipset/ipset.go
@@ -17,8 +17,8 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
-	"os"
 
+	"github.com/pingcap/chaos-mesh/controllers/common"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -71,7 +71,7 @@ func generateIpSetName(networkchaos *v1alpha1.NetworkChaos, namePostFix string) 
 
 // FlushIpSet makes grpc calls to chaosdaemon to save ipset
 func FlushIpSet(ctx context.Context, c client.Client, pod *v1.Pod, ipset pb.IpSet) error {
-	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/networkchaos/iptable/iptable.go
+++ b/controllers/networkchaos/iptable/iptable.go
@@ -16,8 +16,8 @@ package iptable
 import (
 	"context"
 	"fmt"
-	"os"
 
+	"github.com/pingcap/chaos-mesh/controllers/common"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,7 +27,7 @@ import (
 
 // FlushIptables makes grpc call to chaosdaemon to flush iptable
 func FlushIptables(ctx context.Context, c client.Client, pod *v1.Pod, rule pb.Rule) error {
-	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/networkchaos/netem/types.go
+++ b/controllers/networkchaos/netem/types.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"reflect"
 	"strings"
 
@@ -217,10 +216,10 @@ func (r *Reconciler) cleanFinalizersAndRecover(ctx context.Context, networkchaos
 	return nil
 }
 
-func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, networkchaos *v1alpha1.NetworkChaos) error {
+func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, _ *v1alpha1.NetworkChaos) error {
 	r.Log.Info("Try to recover pod", "namespace", pod.Namespace, "name", pod.Name)
 
-	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -268,7 +267,7 @@ func (r *Reconciler) applyPod(ctx context.Context, pod *v1.Pod, networkchaos *v1
 		return err
 	}
 
-	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/networkchaos/tbf/types.go
+++ b/controllers/networkchaos/tbf/types.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -146,7 +145,7 @@ func (r *Reconciler) applyPod(ctx context.Context, pod *v1.Pod, networkchaos *v1
 
 	spec := networkchaos.Spec.Bandwidth
 
-	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -226,10 +225,10 @@ func (r *Reconciler) cleanFinalizersAndRecover(ctx context.Context, networkchaos
 	return nil
 }
 
-func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, networkchaos *v1alpha1.NetworkChaos) error {
+func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, _ *v1alpha1.NetworkChaos) error {
 	r.Log.Info("Try to recover pod", "namespace", pod.Namespace, "name", pod.Name)
 
-	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/networkchaos/tc/tc.go
+++ b/controllers/networkchaos/tc/tc.go
@@ -16,8 +16,8 @@ package tc
 import (
 	"context"
 	"fmt"
-	"os"
 
+	"github.com/pingcap/chaos-mesh/controllers/common"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -27,7 +27,7 @@ import (
 
 // AddQdisc makes grpc call to chaosdaemon to add qdisc
 func AddQdisc(ctx context.Context, c client.Client, pod *v1.Pod, qdisc *pb.Qdisc) error {
-	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -48,7 +48,7 @@ func AddQdisc(ctx context.Context, c client.Client, pod *v1.Pod, qdisc *pb.Qdisc
 
 // AddEmatchFilter makes grpc call to chaosdaemon to add ematch filter
 func AddEmatchFilter(ctx context.Context, c client.Client, pod *v1.Pod, filter *pb.EmatchFilter) error {
-	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func AddEmatchFilter(ctx context.Context, c client.Client, pod *v1.Pod, filter *
 
 // DelQdisc makes grpc to chaosdaemon to delete tc filter
 func DelQdisc(ctx context.Context, c client.Client, pod *v1.Pod, filter *pb.TcFilter) error {
-	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, c, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/podchaos/containerkill/types.go
+++ b/controllers/podchaos/containerkill/types.go
@@ -17,10 +17,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/pingcap/chaos-mesh/controllers/common"
 	"golang.org/x/sync/errgroup"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,7 +135,7 @@ func (r *Reconciler) Object() reconciler.InnerObject {
 func (r *Reconciler) KillContainer(ctx context.Context, pod *v1.Pod, containerID string) error {
 	r.Log.Info("Try to kill container", "namespace", pod.Namespace, "podName", pod.Name, "containerID", containerID)
 
-	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/stresschaos/types.go
+++ b/controllers/stresschaos/types.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -177,7 +176,7 @@ func (r *Reconciler) cleanFinalizersAndRecover(ctx context.Context, chaos *v1alp
 func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.StressChaos) error {
 	r.Log.Info("Try to recover pod", "namespace", pod.Namespace, "name", pod.Name)
 	daemonClient, err := utils.NewChaosDaemonClient(ctx, r.Client,
-		pod, os.Getenv("CHAOS_DAEMON_PORT"))
+		pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -225,9 +224,9 @@ func (r *Reconciler) applyAllPods(ctx context.Context, pods []v1.Pod, chaos *v1a
 
 func (r *Reconciler) applyPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.StressChaos) error {
 	r.Log.Info("Try to apply stress chaos", "namespace",
-		pod.Namespace, "name", pod.Name, "port", os.Getenv("STRESS_SERVER_PORT"))
+		pod.Namespace, "name", pod.Name)
 	daemonClient, err := utils.NewChaosDaemonClient(ctx, r.Client,
-		pod, os.Getenv("CHAOS_DAEMON_PORT"))
+		pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}

--- a/controllers/timechaos/types.go
+++ b/controllers/timechaos/types.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/go-logr/logr"

--- a/controllers/timechaos/types.go
+++ b/controllers/timechaos/types.go
@@ -177,7 +177,7 @@ func (r *Reconciler) cleanFinalizersAndRecover(ctx context.Context, chaos *v1alp
 func (r *Reconciler) recoverPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.TimeChaos) error {
 	r.Log.Info("Try to recover pod", "namespace", pod.Namespace, "name", pod.Name)
 
-	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}
@@ -250,7 +250,7 @@ func (r *Reconciler) applyAllPods(ctx context.Context, pods []v1.Pod, chaos *v1a
 func (r *Reconciler) applyPod(ctx context.Context, pod *v1.Pod, chaos *v1alpha1.TimeChaos) error {
 	r.Log.Info("Try to shift time on pod", "namespace", pod.Namespace, "name", pod.Name)
 
-	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, os.Getenv("CHAOS_DAEMON_PORT"))
+	pbClient, err := utils.NewChaosDaemonClient(ctx, r.Client, pod, common.Cfg.ChaosDaemonPort)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Use a global var to keep the ports we need, so don't need to call `os.GetEnv` too many times

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
