### PR TITLE
Remove set clean start to true

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -41,7 +41,6 @@ func handleFlags() {
 func TestMain(m *testing.M) {
 	// Register test flags, then parse flags.
 	handleFlags()
-	framework.TestContext.CleanStart = true
 
 	// Now that we know which Viper config (if any) was chosen,
 	// parse it and update those options which weren't already set via command line flags


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

This flag is used for cleanup all namespaces expect the system ns such as `kube-system`, `kube-public`, etc.

Though this is useful, it is quite dangerous and error-prone. Especially in the case that you need to use different context to switch between the local e2e k8s and other k8s clusters...