### PR TITLE
use `helm template` instead of `--dry-run`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ yaml: manifests ensure-kustomize
 	$(KUSTOMIZE_BIN) build config/default > manifests/crd.yaml
 
 update-install-script:
-	./hack/update_install.sh
+	./hack/update_install_script.sh
 
 e2e-build:
 	$(GO) build -trimpath  -o test/image/e2e/bin/ginkgo github.com/onsi/ginkgo/ginkgo

--- a/hack/update_install_script.sh
+++ b/hack/update_install_script.sh
@@ -4,14 +4,8 @@ tmp_file="chaos-mesh.yaml"
 tmp_install_scipt="install.sh.bak"
 install_scirpt="install.sh"
 
-helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --dry-run > ${tmp_file}
+helm template chaos-mesh helm/chaos-mesh --namespace=chaos-testing > ${tmp_file}
 
-num=4
-max=$(sed -n '$=' $tmp_file)
-let sLine=max-num+1
-
-sed -i .bak $sLine',$d' $tmp_file
-sed -i .bak '1,9d' $tmp_file
 sed -i .bak '/helm/d' $tmp_file
 sed -i .bak '/Helm/d' $tmp_file
 sed -i .bak 's/tls.crt:.*/tls.crt: \"\$\{TLS_CRT\}\"/g' $tmp_file
@@ -28,7 +22,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: chaos-testing
----
 EOF
 
 cat $tmp_file.bak >> $tmp_file

--- a/install.sh
+++ b/install.sh
@@ -23,7 +23,7 @@ FLAGS:
         --docker-mirror      Use docker mirror to pull image, dockerhub.azk8s.cn => docker.io, gcr.azk8s.cn => gcr.io
         --volume-provisioner Deploy volume provisioner in local Kubernetes cluster
         --local-registry     Deploy local docker registry in local Kubernetes cluster
-        --dry-run            Simulate an install and generate chaos-mesh manifests files
+        --template           Locally render templates
 OPTIONS:
     -v, --version            Version of chaos-mesh, default value: latest
     -l, --local [kind]       Choose a way to run a local kubernetes cluster, supported value: kind,
@@ -59,7 +59,7 @@ main() {
     local local_registry=false
     local crd="https://raw.githubusercontent.com/pingcap/chaos-mesh/master/manifests/crd.yaml"
     local runtime="docker"
-    local dry_run=false
+    local template=false
 
     while [[ $# -gt 0 ]]
     do
@@ -117,8 +117,8 @@ main() {
                 force_chaos_mesh=true
                 shift
                 ;;
-            --dry-run)
-                dry_run=true
+            --template)
+                template=true
                 shift
                 ;;
             --docker-mirror)
@@ -185,7 +185,7 @@ main() {
         runtime="containerd"
     fi
 
-    if $dry_run; then
+    if $template; then
         gen_crd_manifests $crd
         gen_chaos_mesh_manifests "${runtime}"
         exit 0


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Use `helm template` instead of  `--dry-run` to update `install.sh`, So we can run `make update-install-script`  without the Kubernetes cluster environment.