### PR TITLE
Add a script to generate go code from proto files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,8 +216,12 @@ generate: controller-gen
 yaml: manifests ensure-kustomize
 	$(KUSTOMIZE_BIN) build config/default > manifests/crd.yaml
 
+# Generate Go files from Chaos Mesh proto files.
+proto:
+	hack/genproto.sh
+
 update-install-script:
-	./hack/update_install_script.sh
+	hack/update_install_script.sh
 
 e2e-build:
 	$(GO) build -trimpath  -o test/image/e2e/bin/ginkgo github.com/onsi/ginkgo/ginkgo
@@ -265,5 +269,5 @@ install-local-coverage-tools:
 .PHONY: all build test install manifests groupimports fmt vet tidy image \
 	binary docker-push lint generate controller-gen yaml \
 	manager chaosfs chaosdaemon chaos-server ensure-all \
-	dashboard dashboard-server-frontend \
-	gosec-scan
+	dashboard dashboard-server-frontend gosec-scan \
+	proto

--- a/hack/genproto.sh
+++ b/hack/genproto.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Generate all protobuf bindings.
+# Run from repository root.
+set -eu
+
+PROTOC_BIN=${PROTOC_BIN:-protoc}
+
+if ! [[ "$0" =~ "hack/genproto.sh" ]]; then
+	echo "must be run from repository root"
+	exit 255
+fi
+
+DIRS="pkg/chaosdaemon/pb pkg/chaosfs/pb"
+
+echo "generating code"
+for dir in ${DIRS}; do
+	pushd ${dir}
+		${PROTOC_BIN} --go_out=plugins=grpc:. -I=. *.proto
+	popd
+done


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Add a script to generate go code from proto files.
We can easily run it via `make proto`
