### PR TITLE
Support to select pods directly when to create a new experiment

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -110,6 +110,11 @@ type ScopeInfo struct {
 	FieldSelectors      map[string]string `json:"field_selectors" binding:"MapSelectorsValid"`
 	PhaseSelector       []string          `json:"phase_selectors" binding:"PhaseSelectorsValid"`
 
+	// Pods is a map of string keys and a set values that used to select pods.
+	// The key defines the namespace which pods belong,
+	// and the each values is a set of pod names.
+	Pods map[string][]string `json:"pods" binding:"PodsValid"`
+
 	Mode  string `json:"mode" binding:"oneof='' 'one' 'all' 'fixed' 'fixed' 'fixed-percent' 'random-max-percent'"`
 	Value string `json:"value" binding:"ValueValid"`
 }
@@ -138,6 +143,10 @@ func (s *ScopeInfo) parseSelector() v1alpha1.SelectorSpec {
 
 	for _, ph := range s.PhaseSelector {
 		selector.PodPhaseSelectors = append(selector.PodPhaseSelectors, ph)
+	}
+
+	if s.Pods != nil {
+		selector.Pods = s.Pods
 	}
 
 	return selector

--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -122,9 +122,6 @@ type SelectorInfo struct {
 	// The key defines the namespace which pods belong,
 	// and the each values is a set of pod names.
 	Pods map[string][]string `json:"pods" binding:"PodsValid"`
-
-	Mode  string `json:"mode" binding:"oneof='' 'one' 'all' 'fixed' 'fixed' 'fixed-percent' 'random-max-percent'"`
-	Value string `json:"value" binding:"ValueValid"`
 }
 
 // ParseSelector parses SelectorInfo to v1alpha1.SelectorSpec


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists--> 

Support to set pods directly, so we can don't need to fill other selectors and just select the specific pods by clicking on the front-end. 

This pr can meet some cases, such as some pods don't have any labels for selectors. 

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
