### PR TITLE
fix swagger api

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -793,8 +793,8 @@ func (s *Service) listExperiments(c *gin.Context) {
 // @Param namespace path string true "namespace"
 // @Param name path string true "name"
 // @Param kind path string true "kind" Enums(PodChaos, IoChaos, NetworkChaos, TimeChaos, KernelChaos, StressChaos)
-// @Success 200 ExperimentInfo
 // @Router /api/experiments/detail/{kind}/{namespace}/{name} [GET]
+// @Success 200 {object} ExperimentInfo
 // @Failure 400 {object} utils.APIError
 // @Failure 500 {object} utils.APIError
 func (s *Service) getExperimentDetail(c *gin.Context) {


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists--> 

fix: 
```
12:20:27  2020/05/30 04:20:26 Generate general API Info, search dir:./
12:20:27  [0m[91m2020/05/30 04:20:27 ParseComment error in file pkg/apiserver/experiment/experiment.go :can not parse response comment "200 ExperimentInfo"
```

### What is changed and how does it work?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
