### PR TITLE
set spec.Bandwidth and spec.Direction only when the action is bandwidth

### DIFF
--- a/pkg/apiserver/experiment/experiment.go
+++ b/pkg/apiserver/experiment/experiment.go
@@ -321,9 +321,12 @@ func (s *Service) createNetworkChaos(exp *ExperimentInfo) error {
 			Loss:      exp.Target.NetworkChaos.Loss,
 			Duplicate: exp.Target.NetworkChaos.Duplicate,
 			Corrupt:   exp.Target.NetworkChaos.Corrupt,
-			Bandwidth: exp.Target.NetworkChaos.Bandwidth,
-			Direction: v1alpha1.Direction(exp.Target.NetworkChaos.Direction),
 		},
+	}
+
+	if exp.Target.NetworkChaos.Action == string(v1alpha1.BandwidthAction) {
+		chaos.Spec.Bandwidth = exp.Target.NetworkChaos.Bandwidth
+		chaos.Spec.Direction = v1alpha1.Direction(exp.Target.NetworkChaos.Direction)
 	}
 
 	if exp.Scheduler.Cron != "" {


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists--> 

Inject a network delay by API, an error was returned:

<img width="484" alt="WeChatWorkScreenshot_71d88cde-24e8-478f-88f6-fe3231a8e11f" src="https://user-images.githubusercontent.com/22956341/83325604-f872e300-a29f-11ea-9c9a-acfac50727af.png">


### What is changed and how does it work? 

set spec.Bandwidth and spec.Direction only when the action is bandwidth

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
