### PR TITLE
fix ui not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,10 +162,13 @@ failpoint-disable: $(GOBIN)/failpoint-ctl
 vet:
 	$(CGOENV) go vet ./...
 
-tidy:
+tidy: clean
 	@echo "go mod tidy"
 	GO111MODULE=on go mod tidy
 	git diff --quiet go.mod go.sum
+
+clean:
+	rm -rf docs/docs.go
 
 taily-build:
 	if [ "$(shell docker ps --filter=name=$@ -q)" = "" ]; then \

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.4.0
-	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/ethercflow/hookfs v0.3.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/gin-gonic/gin v1.6.2
@@ -47,9 +46,12 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/robfig/cron/v3 v3.0.0
 	github.com/shirou/gopsutil v0.0.0-20180427012116-c95755e4bcd7
+	github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 // indirect
+	github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0
+	github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd
 	github.com/spf13/cobra v0.0.6 // indirect
 	github.com/swaggo/http-swagger v0.0.0-20200308142732-58ac5e232fba
-	github.com/swaggo/swag v1.6.5 // indirect
+	github.com/swaggo/swag v1.6.5
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20200122045848-3419fae592fc // indirect
 	github.com/vishvananda/netlink v1.0.0
 	github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df

--- a/go.sum
+++ b/go.sum
@@ -162,8 +162,6 @@ github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
-github.com/elazarl/go-bindata-assetfs v1.0.0 h1:G/bYguwHIzWq9ZoyUQqrjTmJbbYn3j3CKKpKinvZLFk=
-github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e h1:p1yVGRW3nmb85p1Sh1ZJSDm4A4iKLS5QNbvUHMgGu/M=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -454,6 +452,7 @@ github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46s
 github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
 github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
+github.com/kisielk/errcheck v1.2.0 h1:reN85Pxc5larApoH1keMBiu2GWtPqXQ1nc9gx+jOU+E=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v0.0.0-20161130080628-0de1eaf82fa3/go.mod h1:jxZFDH7ILpTPQTk+E2s+z4CUas9lVNjIuKR4c5/zKgM=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -671,8 +670,14 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+D
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e/go.mod h1:TDJrrUr11Vxrven61rcy3hJMUqaf/CLWYhHNPmT14Lk=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749 h1:bUGsEnyNbVPw06Bs80sCeARAlK8lhwqGyi6UT8ymuGk=
+github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
+github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0 h1:mj/nMDAwTBiaCqMEs4cYCqF7pO6Np7vhy1D1wcQGz+E=
+github.com/shurcooL/httpgzip v0.0.0-20190720172056-320755c1c1b0/go.mod h1:919LwcH0M7/W4fcZ0/jy0qGght1GIhqyS/EgWGH2j5Q=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd h1:ug7PpSOB5RBPK1Kg6qskGBoP3Vnj/aNYFTznWvlkGo0=
+github.com/shurcooL/vfsgen v0.0.0-20181202132449-6a9ea43bcacd/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=

--- a/hack/embed_ui_assets.sh
+++ b/hack/embed_ui_assets.sh
@@ -21,28 +21,23 @@ cd "$PROJECT_DIR"
 export GOBIN=$PROJECT_DIR/bin
 export PATH=$GOBIN:$PATH
 
-if [ "${NO_ASSET_BUILD_TAG:-}" = "1" ]; then
-  BUILD_TAG_PARAMETER=""
-else
-  BUILD_TAG_PARAMETER="-tags ${ASSET_BUILD_TAG:-ui_server}"
-fi
-
 echo "+ Preflight check"
 if [ ! -d "ui/build" ]; then
   echo "  - Error: UI assets must be built first"
   exit 1
 fi
 
-echo "+ Install bindata tools"
-go install github.com/elazarl/go-bindata-assetfs/go-bindata-assetfs
-go install github.com/go-bindata/go-bindata/v3/go-bindata
-
-echo "+ Clean up go mod"
-go mod tidy
+if [ "${NO_ASSET_BUILD_TAG:-}" = "1" ]; then
+  BUILD_TAG_PARAMETER=""
+else
+  BUILD_TAG_PARAMETER=${ASSET_BUILD_TAG:-ui_server}
+fi
 
 echo "+ Embed UI assets"
 
-go-bindata-assetfs -pkg uiserver -prefix ui $BUILD_TAG_PARAMETER ui/build/...
+go run tools/assets_generate/main.go $BUILD_TAG_PARAMETER
+
+
 HANDLER_PATH=pkg/uiserver/embedded_assets_handler.go
-mv bindata_assetfs.go $HANDLER_PATH
+mv assets_vfsdata.go $HANDLER_PATH
 echo "  - Assets handler written to $HANDLER_PATH"

--- a/pkg/uiserver/empty_asserts_handler.go
+++ b/pkg/uiserver/empty_asserts_handler.go
@@ -14,10 +14,6 @@
 
 package uiserver
 
-import (
-	assetfs "github.com/elazarl/go-bindata-assetfs"
-)
+import "net/http"
 
-func assetFS() *assetfs.AssetFS {
-	return nil
-}
+var assets http.FileSystem

--- a/pkg/uiserver/server.go
+++ b/pkg/uiserver/server.go
@@ -23,7 +23,7 @@ import (
 // Handler returns a FileServer `http.Handler` to handle http request.
 func Handler(root http.FileSystem) http.Handler {
 	if root != nil {
-		return httpgzip.FileServer(root, httpgzip.FileServerOptions{IndexHTML: true, ServeError: fallback(root)})
+		return httpgzip.FileServer(root, httpgzip.FileServerOptions{IndexHTML: true, ServeError: fallback})
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -36,10 +36,8 @@ func AssetFS() http.FileSystem {
 	return assets
 }
 
-func fallback(fs http.FileSystem) func(w http.ResponseWriter, r *http.Request, _ error) {
-	return func(w http.ResponseWriter, r *http.Request, _ error) {
-		localRedirect(w, r, "index.html")
-	}
+func fallback(w http.ResponseWriter, r *http.Request, _ error) {
+	localRedirect(w, r, ".")
 }
 
 // localRedirect gives a Moved Permanently response.

--- a/tools/assets_generate/main.go
+++ b/tools/assets_generate/main.go
@@ -11,14 +11,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build tools
-
-package tools
+package main
 
 import (
-	_ "github.com/mgechev/revive"
-	_ "github.com/pingcap/failpoint/failpoint-ctl"
-	_ "github.com/swaggo/swag/cmd/swag"
-	_ "golang.org/x/tools/cmd/goimports"
-	_ "sigs.k8s.io/controller-tools/cmd/controller-gen"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/shurcooL/vfsgen"
 )
+
+func main() {
+	buildTag := ""
+	if len(os.Args) > 1 {
+		buildTag = os.Args[1]
+	}
+
+	fs := http.Dir("ui/build")
+	err := vfsgen.Generate(fs, vfsgen.Options{
+		BuildTags:    buildTag,
+		PackageName:  "uiserver",
+		VariableName: "assets",
+	})
+	if err != nil {
+		log.Fatalln(err)
+	}
+}


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists--> 

We use single page applications and the URL will be modified by front-end, so some url can't be accessed, such as: 

![企业微信截图_13e08d55-7855-4921-a441-a5747749ba83](https://user-images.githubusercontent.com/22956341/83350196-178b7680-a36d-11ea-87d9-1d8a1b08d7dc.png)


### What is changed and how does it work? 

* Migrate from go-bindata to vfsgen
* Add `ServeError` function to redirect `index.html`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
