### PR TITLE
Fix panic when incrementing metric

### DIFF
--- a/controllers/metrics/metrics.go
+++ b/controllers/metrics/metrics.go
@@ -33,7 +33,7 @@ type ChaosCollector struct {
 	ConfigTemplates     *prometheus.GaugeVec
 	InjectionConfigs    *prometheus.GaugeVec
 	TemplateNotExist    *prometheus.CounterVec
-	TemplateLoadError   *prometheus.CounterVec
+	TemplateLoadError   prometheus.Counter
 	ConfigNameDuplicate *prometheus.CounterVec
 	InjectRequired      *prometheus.CounterVec
 	Injections          *prometheus.CounterVec
@@ -67,10 +67,10 @@ func NewChaosCollector(store cache.Cache, registerer prometheus.Registerer) *Cha
 			Name: "chaos_mesh_config_name_duplicate_total",
 			Help: "Total number of config name duplication error",
 		}, []string{"namespace", "config"}),
-		TemplateLoadError: prometheus.NewCounterVec(prometheus.CounterOpts{
+		TemplateLoadError: prometheus.NewCounter(prometheus.CounterOpts{
 			Name: "chaos_mesh_template_load_failed_total",
 			Help: "Total number of failures when rendering config args to template",
-		}, []string{"namespace", "template", "config"}),
+		}),
 		InjectRequired: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "chaos_mesh_inject_required_total",
 			Help: "Total number of injections required",

--- a/pkg/webhook/config/watcher/watcher.go
+++ b/pkg/webhook/config/watcher/watcher.go
@@ -312,7 +312,7 @@ func (c *K8sConfigMapWatcher) GetConfigs() ([]*config.TemplateArgs, error) {
 			if err != nil {
 				log.Error(err, "failed to load template args", "payload", payload)
 				if c.metrics != nil {
-					c.metrics.TemplateLoadError.WithLabelValues(conf.Namespace, conf.Template, conf.Name).Inc()
+					c.metrics.TemplateLoadError.Inc()
 				}
 				continue
 			}


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Fix #589 

### What is changed and how does it work?

The root cause of #589 is that when the template is wrong, like the `conf.template` is not set, then the code below will cause a panic

```
c.metrics.TemplateLoadError.WithLabelValues(conf.Namespace, conf.Template, conf.Name).Inc()
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - E2E test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has Go code change
 - Has CI related scripts change
 - Has Terraform scripts change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to update the documentation

### Does this PR introduce a user-facing change?:
<!--
If no, just leave the release note block below as is.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
