### PR TITLE
chore: Bump golang version to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
           - build
           - test
     steps:
-      - name: Set up Go 1.13
+      - name: Set up Go 1.14
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.14.4
         id: go
 
       - name: Check out code into the Go module directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine3.10 AS build_base
+FROM golang:1.14.4-alpine3.12 AS build_base
 
 ARG HTTPS_PROXY
 ARG HTTP_PROXY


### PR DESCRIPTION
Signed-off-by: yeya24 <yb532204897@gmail.com>

### What problem does this PR solve? <!--add and issue link with summary if exists-->

Bump golang to 1.14, which contains many improvements compared to 1.13.

Highlights: https://blog.golang.org/go1.14
