### PR TITLE
docs: should use bash

### DIFF
--- a/website/docs/installation/get_started_on_kind.md
+++ b/website/docs/installation/get_started_on_kind.md
@@ -18,7 +18,7 @@ curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh
 
 `install.sh` is an automation shell script that helps you install dependencies such as `kubectl`, `Helm`, `kind`, and `kubernetes`, and deploy Chaos Mesh itself.
 
-After executing the above command, you need to verify if the Chaos Mesh is installed correctly. 
+After executing the above command, you need to verify if the Chaos Mesh is installed correctly.
 
 You also can use [Helm](https://helm.sh/) to [install Chaos Mesh manually](installation#install-by-helm).
 
@@ -30,7 +30,7 @@ Verify if the chaos mesh is running
 kubectl get pod -n chaos-testing
 ```
 
-Expected output: 
+Expected output:
 
 ```bash
 NAME                                        READY   STATUS    RESTARTS   AGE

--- a/website/docs/installation/get_started_on_kind.md
+++ b/website/docs/installation/get_started_on_kind.md
@@ -46,7 +46,7 @@ chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 You can uninstall Chaos Mesh by deleting the namespace.
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | sh -s -- --template | kubectl delete -f -
+curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | bash -s -- --template | kubectl delete -f -
 ```
 
 ## Clean kind cluster

--- a/website/docs/installation/get_started_on_kind.md
+++ b/website/docs/installation/get_started_on_kind.md
@@ -13,7 +13,7 @@ Before deployment, make sure [Docker](https://docs.docker.com/install/) is insta
 ## Install Chaos Mesh
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | sh -s -- --local kind
+curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | bash -s -- --local kind
 ```
 
 `install.sh` is an automation shell script that helps you install dependencies such as `kubectl`, `Helm`, `kind`, and `kubernetes`, and deploy Chaos Mesh itself.

--- a/website/docs/installation/get_started_on_minikube.md
+++ b/website/docs/installation/get_started_on_minikube.md
@@ -40,7 +40,7 @@ Perform the following steps to set up the local Kubernetes environment:
 ## Setp 2: Install Chaos Mesh
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | sh
+curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | bash
 ```
 
 The above command install all the CRDs, required service account configuration, and all components.
@@ -72,7 +72,7 @@ chaos-dashboard-d998856f6-vgrjs             1/1     Running   0          3m40s
 You can uninstall Chaos Mesh by deleting the namespace.
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | sh -s -- --template | kubectl delete -f -
+curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | bash -s -- --template | kubectl delete -f -
 ```
 
 ## Limitations

--- a/website/docs/installation/installation.md
+++ b/website/docs/installation/installation.md
@@ -8,8 +8,8 @@ This document describes how to install Chaos Mesh to perform chaos experiments a
 
 If you want to try Chaos Mesh on your your laptop (Linux or macOS), you can refer the following two documents:
 
-* [Get started on kind](get_started_on_kind)
-* [Get started on minikube](get_started_on_minikube)
+- [Get started on kind](get_started_on_kind)
+- [Get started on minikube](get_started_on_minikube)
 
 ## Prerequisites
 
@@ -18,11 +18,10 @@ Before deploying Chaos Mesh, make sure the following items have been installed:
 - Kubernetes version >= 1.12
 - [RBAC](https://kubernetes.io/docs/admin/authorization/rbac) enabled (optional)
 
-
 ## Install Chaos Mesh
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | sh
+curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | bash
 ```
 
 The above command install all the CRDs, required service account configuration, and all components.
@@ -36,7 +35,7 @@ Verify if the chaos mesh is running
 kubectl get pod -n chaos-testing
 ```
 
-Expected output: 
+Expected output:
 
 ```bash
 NAME                                        READY   STATUS    RESTARTS   AGE
@@ -57,7 +56,7 @@ curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh
 
 ## Install by Helm
 
-You also can install Chaos Mesh by [Helm](https://helm.sh). 
+You also can install Chaos Mesh by [Helm](https://helm.sh).
 Before you start installing, make sure that Helm v2 or Helm v3 is installed correctly.
 
 ### Step 1: Get Chaos Mesh
@@ -79,65 +78,64 @@ kubectl apply -f manifests/crd.yaml
 
 Depending on your environment, there are two methods of installing Chaos Mesh:
 
-* Install in Docker environment
+- Install in Docker environment
 
-    1. Create namespace `chaos-testing`:
+  1. Create namespace `chaos-testing`:
 
-        ```bash
-        kubectl create ns chaos-testing
-        ```
+     ```bash
+     kubectl create ns chaos-testing
+     ```
 
-    2. Install Chaos Mesh using Helm:
+  2. Install Chaos Mesh using Helm:
 
-        * For Helm 2.X
+     - For Helm 2.X
 
-        ```bash
-        helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing
-        ```
+     ```bash
+     helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing
+     ```
 
-        * For Helm 3.X
+     - For Helm 3.X
 
-        ```bash
-        helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing
-        ```
+     ```bash
+     helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing
+     ```
 
-    3. Check whether Chaos Mesh pods are installed:
+  3. Check whether Chaos Mesh pods are installed:
 
-        ```
-        kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh
-        ```
+     ```bash
+     kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh
+     ```
 
-* Install in containerd environment (kind)
+- Install in containerd environment (kind)
 
-    1. Create namespace `chaos-testing`:
+  1. Create namespace `chaos-testing`:
 
-        ```bash
-        kubectl create ns chaos-testing
-        ```
+     ```bash
+     kubectl create ns chaos-testing
+     ```
 
-    2. Install Chaos Mesh using Helm:
+  2. Install Chaos Mesh using Helm:
 
-        * for Helm 2.X
+     - for Helm 2.X
 
-        ```bash
-        helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-        ```
+     ```bash
+     helm install helm/chaos-mesh --name=chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     ```
 
-        * for Helm 3.X
+     - for Helm 3.X
 
-        ```bash
-        helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
-        ```
+     ```bash
+     helm install chaos-mesh helm/chaos-mesh --namespace=chaos-testing --set chaosDaemon.runtime=containerd --set chaosDaemon.socketPath=/run/containerd/containerd.sock
+     ```
 
-    3. Check whether Chaos Mesh pods are installed:
+  3. Check whether Chaos Mesh pods are installed:
 
-        ```bash
-        kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh
-        ```
+     ```bash
+     kubectl get pods --namespace chaos-testing -l app.kubernetes.io/instance=chaos-mesh
+     ```
 
 > **Note:**
 >
 > Currently, Chaos Dashboard is not installed by default. If you want to try it out, add `--set dashboard.create=true` in the Helm commands above. Refer to [Configuration](../helm/chaos-mesh/README.md#configuration) for more information.
 
 After executing the above commands, you should be able to see the output indicating that all Chaos Mesh pods are up and running. Otherwise, check the current environment according to the prompt message or create an [issue](https://github.com/pingcap/chaos-mesh/issues) for help.
-

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -9,7 +9,7 @@ import styles from './styles.module.css';
 import CodeSnippet from "@site/src/theme/CodeSnippet";
 
 const install = `# Install on Kubernetes 
-curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | sh`
+curl -sSL https://raw.githubusercontent.com/pingcap/chaos-mesh/master/install.sh | bash`
 
 function Home() {
   const context = useDocusaurusContext();


### PR DESCRIPTION
### What problem does this PR solve?

When I try to install chaos mesh with kind by https://chaos-mesh.org/docs/installation/get_started_on_kind#install-chaos-mesh, then I run into this error:

```
sh: 381: Syntax error: Bad for loop variable
```

After rechecking the `install.sh`, I think this command should use `bash`.

