### PR TITLE
fix chaos-dashboard panic

### DIFF
--- a/pkg/store/event/event.go
+++ b/pkg/store/event/event.go
@@ -320,6 +320,9 @@ func (e *eventStore) DeleteByFinishTime(_ context.Context, ttl time.Duration) er
 	}
 	nowTime := time.Now()
 	for _, et := range eventList {
+		if et.FinishTime == nil {
+			continue
+		}
 		if et.FinishTime.Add(ttl).Before(nowTime) {
 			if err := e.db.Model(core.Event{}).Unscoped().Delete(*et).Error; err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: cwen0 <cwenyin0@gmail.com>

### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. --> 

Fix #649  

```
E0624 16:21:19.119160       1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 181 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1880780, 0x2afd530)
        /go/pkg/mod/k8s.io/apimachinery@v0.17.1-beta.0/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /go/pkg/mod/k8s.io/apimachinery@v0.17.1-beta.0/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1880780, 0x2afd530)
        /usr/local/go/src/runtime/panic.go:969 +0x166
github.com/pingcap/chaos-mesh/pkg/store/event.(*eventStore).DeleteByFinishTime(0xc00019c908, 0x1e73fc0, 0xc000046028, 0x2260ff9290000, 0x0, 0x0)
        /src/pkg/store/event/event.go:323 +0xf7
```

### What is changed and how does it work?

* Check `event.FinishTime` before using it