### PR TITLE
Document: modify IOCChaos to IOChaos

### DIFF
--- a/website/docs/user_guides/sidecar_configmap.md
+++ b/website/docs/user_guides/sidecar_configmap.md
@@ -8,7 +8,7 @@ This document guides you to define a specified sidecar ConfigMap for your applic
 
 ## Why do we need a specified Sidecar ConfigMap?
 
-Chaos Mesh runs a [fuse-daemon](https://www.kernel.org/doc/Documentation/filesystems/fuse.txt) server in [sidecar container](https://www.magalix.com/blog/the-sidecar-pattern) for implementing file system IOCChaos.
+Chaos Mesh runs a [fuse-daemon](https://www.kernel.org/doc/Documentation/filesystems/fuse.txt) server in [sidecar container](https://www.magalix.com/blog/the-sidecar-pattern) for implementing file system IOChaos.
 
 In sidecar container, fuse-daemon needs to mount the data directory of application by [fusermount](http://manpages.ubuntu.com/manpages/bionic/en/man1/fusermount.1.html) before the application starts.
 


### PR DESCRIPTION
### What problem does this PR solve?
<!-- Add an issue link with a summary if exists. -->
In user_guides/sidecar_configmap.md, change `IOCChaos` to `IOChaos`.

### What is changed and how does it work?
In user_guides/sidecar_configmap.md, change `IOCChaos` to `IOChaos`.