### PR TITLE
Add stress-ng to target pid namespace

### DIFF
--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -21,7 +21,7 @@ controllerManager:
   replicaCount: 1
 
   image: pingcap/chaos-mesh:latest
-  imagePullPolicy: Never
+  imagePullPolicy: Always
 
   nameOverride: ""
   fullnameOverride: ""
@@ -54,7 +54,7 @@ controllerManager:
 
 chaosDaemon:
   image: pingcap/chaos-daemon:latest
-  imagePullPolicy: Never
+  imagePullPolicy: Always
   grpcPort: 31767
   httpPort: 31766
 
@@ -96,7 +96,7 @@ dashboard:
   serviceAccount: chaos-controller-manager
 
   image: pingcap/chaos-dashboard:latest
-  imagePullPolicy: Never
+  imagePullPolicy: Always
 
   nodeSelector: {}
 
@@ -256,7 +256,7 @@ webhook:
 bpfki:
   create: false
   image: pingcap/chaos-kernel:latest
-  imagePullPolicy: Never
+  imagePullPolicy: Always
   grpcPort: 50051
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -11,7 +11,7 @@ rbac:
   create: true
 
 # enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon.
-enableProfiling: false
+enableProfiling: true
 
 kubectlImage: bitnami/kubectl:latest
 
@@ -21,7 +21,7 @@ controllerManager:
   replicaCount: 1
 
   image: pingcap/chaos-mesh:latest
-  imagePullPolicy: Always
+  imagePullPolicy: Never
 
   nameOverride: ""
   fullnameOverride: ""
@@ -54,7 +54,7 @@ controllerManager:
 
 chaosDaemon:
   image: pingcap/chaos-daemon:latest
-  imagePullPolicy: Always
+  imagePullPolicy: Never
   grpcPort: 31767
   httpPort: 31766
 
@@ -96,7 +96,7 @@ dashboard:
   serviceAccount: chaos-controller-manager
 
   image: pingcap/chaos-dashboard:latest
-  imagePullPolicy: Always
+  imagePullPolicy: Never
 
   nodeSelector: {}
 
@@ -256,7 +256,7 @@ webhook:
 bpfki:
   create: false
   image: pingcap/chaos-kernel:latest
-  imagePullPolicy: Always
+  imagePullPolicy: Never
   grpcPort: 50051
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -11,7 +11,7 @@ rbac:
   create: true
 
 # enableProfiling is a flag to enable pprof in controller-manager and chaos-daemon.
-enableProfiling: true
+enableProfiling: false
 
 kubectlImage: bitnami/kubectl:latest
 
@@ -64,15 +64,15 @@ chaosDaemon:
 
   # runtime specifies which container runtime to use. Currently
   # we only supports docker and containerd.
-  # runtime: docker
+  runtime: docker
 
   # socketPath specifies the container runtime socket.
-  # socketPath: /var/run/docker.sock
+  socketPath: /var/run/docker.sock
 
   # If you are using Kind or using containerd as CRI, you can use the
   # config below to use containerd as the runtime in chaos-daemon.
-  runtime: containerd
-  socketPath: /run/containerd/containerd.sock
+  # runtime: containerd
+  # socketPath: /run/containerd/containerd.sock
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/helm/chaos-mesh/values.yaml
+++ b/helm/chaos-mesh/values.yaml
@@ -64,15 +64,15 @@ chaosDaemon:
 
   # runtime specifies which container runtime to use. Currently
   # we only supports docker and containerd.
-  runtime: docker
+  # runtime: docker
 
   # socketPath specifies the container runtime socket.
-  socketPath: /var/run/docker.sock
+  # socketPath: /var/run/docker.sock
 
   # If you are using Kind or using containerd as CRI, you can use the
   # config below to use containerd as the runtime in chaos-daemon.
-  # runtime: containerd
-  # socketPath: /run/containerd/containerd.sock
+  runtime: containerd
+  socketPath: /run/containerd/containerd.sock
 
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious

--- a/images/chaos-daemon/Dockerfile
+++ b/images/chaos-daemon/Dockerfile
@@ -3,6 +3,6 @@ FROM alpine:3.10
 ARG HTTPS_PROXY
 ARG HTTP_PROXY
 
-RUN apk add --no-cache tzdata iptables ipset stress-ng iproute2
+RUN apk add --no-cache tzdata iptables ipset stress-ng iproute2 util-linux
 
 COPY --from=pingcap/binary /src/bin/chaos-daemon /usr/local/bin/chaos-daemon

--- a/pkg/chaosdaemon/ipset_server.go
+++ b/pkg/chaosdaemon/ipset_server.go
@@ -38,7 +38,7 @@ func (s *daemonServer) FlushIpSet(ctx context.Context, req *pb.IpSetRequest) (*e
 		return nil, err
 	}
 
-	nsPath := GenNetnsPath(pid)
+	nsPath := GetNsPath(pid, netNS)
 
 	// TODO: lock every ipset when working on it
 

--- a/pkg/chaosdaemon/iptables_server.go
+++ b/pkg/chaosdaemon/iptables_server.go
@@ -40,7 +40,7 @@ func (s *daemonServer) FlushIptables(ctx context.Context, req *pb.IpTablesReques
 		return nil, err
 	}
 
-	nsPath := GenNetnsPath(pid)
+	nsPath := GetNsPath(pid, netNS)
 	rule := req.Rule
 
 	format := ""

--- a/pkg/chaosdaemon/netlink_linux.go
+++ b/pkg/chaosdaemon/netlink_linux.go
@@ -25,7 +25,7 @@ type toQdiscFunc func(*netlink.Handle, netlink.Link) netlink.Qdisc
 func applyQdisc(pid uint32, toQdisc toQdiscFunc) error {
 	log.Info("Apply qdisc on PID", "pid", pid)
 
-	ns, err := netns.GetFromPath(GenNetnsPath(pid))
+	ns, err := netns.GetFromPath(GetNsPath(pid, netNS))
 	if err != nil {
 		log.Error(err, "failed to find network namespace", "pid", pid)
 		return err
@@ -60,7 +60,7 @@ func applyQdisc(pid uint32, toQdisc toQdiscFunc) error {
 func deleteQdisc(pid uint32, toQdisc toQdiscFunc) error {
 	log.Info("Delete qdisc on PID", "pid", pid)
 
-	ns, err := netns.GetFromPath(GenNetnsPath(pid))
+	ns, err := netns.GetFromPath(GetNsPath(pid, netNS))
 	if err != nil {
 		log.Error(err, "failed to find network namespace", "pid", pid)
 		return err

--- a/pkg/chaosdaemon/stress_server_linux.go
+++ b/pkg/chaosdaemon/stress_server_linux.go
@@ -92,7 +92,7 @@ func (s *daemonServer) ExecStressors(ctx context.Context,
 		if err, ok := cmd.Wait().(*exec.ExitError); ok {
 			status := err.Sys().(syscall.WaitStatus)
 			if status.Signaled() && status.Signal() == syscall.SIGKILL {
-				log.Info("Stressors cancelled", "request", req, "exitStatus", status.ExitStatus())
+				log.Info("Stressors cancelled", "request", req)
 			} else {
 				log.Error(err, "stressors exited accidentally", "request", req)
 			}

--- a/pkg/chaosdaemon/stress_server_linux.go
+++ b/pkg/chaosdaemon/stress_server_linux.go
@@ -65,6 +65,7 @@ func (s *daemonServer) ExecStressors(ctx context.Context,
 	}
 
 	cmd := withPidNS(ctx, GetNsPath(pid, pidNS), "stress-ng", strings.Fields(req.Stressors)...)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/chaosdaemon/stress_server_linux.go
+++ b/pkg/chaosdaemon/stress_server_linux.go
@@ -95,7 +95,7 @@ func (s *daemonServer) ExecStressors(ctx context.Context,
 		if err, ok := cmd.Wait().(*exec.ExitError); ok {
 			status := err.Sys().(syscall.WaitStatus)
 			if status.Signaled() && status.Signal() == syscall.SIGKILL {
-				log.Info("Stressors cancelled", "request", req)
+				log.Info("Stressors cancelled", "request", req, "exitStatus", status.ExitStatus())
 			} else {
 				log.Error(err, "stressors exited accidentally", "request", req)
 			}

--- a/pkg/chaosdaemon/tc_linux.go
+++ b/pkg/chaosdaemon/tc_linux.go
@@ -30,7 +30,7 @@ func applyTc(ctx context.Context, pid uint32, args ...string) error {
 		}
 	}
 
-	nsPath := GenNetnsPath(pid)
+	nsPath := GetNsPath(pid, netNS)
 
 	cmd := withNetNS(ctx, nsPath, "tc", args...)
 	log.Info("tc command", "command", cmd.String(), "args", args)

--- a/pkg/chaosdaemon/util.go
+++ b/pkg/chaosdaemon/util.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"os/exec"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -184,9 +185,29 @@ func CreateContainerRuntimeInfoClient(containerRuntime string) (ContainerRuntime
 	return cli, nil
 }
 
-// GetNetnsPath returns network namespace path
-func GenNetnsPath(pid uint32) string {
-	return fmt.Sprintf("%s/%d/ns/net", defaultProcPrefix, pid)
+type nsType string
+
+const (
+	mountNS nsType = "mnt"
+	utsNS   nsType = "uts"
+	ipcNS   nsType = "ipc"
+	netNS   nsType = "net"
+	pidNS   nsType = "pid"
+	userNS  nsType = "user"
+)
+
+var nsArgMap = map[nsType]string{
+	mountNS: "m",
+	utsNS:   "u",
+	ipcNS:   "i",
+	netNS:   "n",
+	pidNS:   "p",
+	userNS:  "U",
+}
+
+// GetNsPath returns corresponding namespace path
+func GetNsPath(pid uint32, typ nsType) string {
+	return fmt.Sprintf("%s/%d/ns/%s", defaultProcPrefix, pid, string(typ))
 }
 
 func withNetNS(ctx context.Context, nsPath string, cmd string, args ...string) *exec.Cmd {
@@ -196,8 +217,43 @@ func withNetNS(ctx context.Context, nsPath string, cmd string, args ...string) *
 		return f(ctx, nsPath, cmd, args...)
 	}
 
-	// BusyBox's nsenter is very confusing. This usage is found by several attempts
-	args = append([]string{"-n" + nsPath, "--", cmd}, args...)
+	return withNS(ctx, []nsOption{{
+		Typ:  netNS,
+		Path: nsPath,
+	}}, cmd, args...)
+}
+
+func withPidNS(ctx context.Context, nsPath string, cmd string, args ...string) *exec.Cmd {
+	// Mock point to return mock Cmd in unit test
+	if c := mock.On("MockWithPidNs"); c != nil {
+		f := c.(func(context.Context, string, string, ...string) *exec.Cmd)
+		return f(ctx, nsPath, cmd, args...)
+	}
+
+	return withNS(ctx, []nsOption{{
+		Typ:  pidNS,
+		Path: nsPath,
+	}}, cmd, args...)
+}
+
+type nsOption struct {
+	Typ  nsType
+	Path string
+}
+
+func withNS(ctx context.Context, options []nsOption, cmd string, args ...string) *exec.Cmd {
+	// Mock point to return mock Cmd in unit test
+	if c := mock.On("MockWithNs"); c != nil {
+		f := c.(func(context.Context, []nsOption, string, ...string) *exec.Cmd)
+		return f(ctx, options, cmd, args...)
+	}
+
+	args = append([]string{"-F", "--", cmd}, args...)
+	for _, option := range options {
+		args = append([]string{"-" + nsArgMap[option.Typ] + option.Path}, args...)
+	}
+
+	log.Info("running command", "command", "nsenter "+strings.Join(args, " "))
 
 	return exec.CommandContext(ctx, "nsenter", args...)
 }

--- a/pkg/chaosdaemon/util.go
+++ b/pkg/chaosdaemon/util.go
@@ -248,7 +248,7 @@ func withNS(ctx context.Context, options []nsOption, cmd string, args ...string)
 		return f(ctx, options, cmd, args...)
 	}
 
-	args = append([]string{"-F", "--", cmd}, args...)
+	args = append([]string{"--", cmd}, args...)
 	for _, option := range options {
 		args = append([]string{"-" + nsArgMap[option.Typ] + option.Path}, args...)
 	}


### PR DESCRIPTION
### What problem does this PR solve?

With this PR, users can see stress-ng process in corresponding pod. This PR also uses a util-linux version of nsenter rather than busybox's one. The util-linux's nsenter is more stable and seems to have less bugs.

### What is changed and how does it work?

### Check List
<!-- Remove the items that are not applicable. -->

Tests

- Manual test

Code changes

- Has Go code change

```release-note
NONE
```
